### PR TITLE
Refactor/implement feedback

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,24 @@
 # Release Notes
 
+## v0.12.1 — 2026-03-28
+
+### Fix: camera picker modal, draggable settings panel, audio settings restored
+
+**Camera picker rework**
+- Replaced the small floating tooltip with a proper centered modal: dark overlay with blur, animated card, full-width camera buttons with icon and label, ✕ close button, Cancel button, and click-backdrop-to-dismiss
+
+**Draggable settings panel**
+- Settings panel is now a `position: fixed` floating panel — no longer anchored above the gear button where it could be clipped off-screen
+- Drag handle at the top lets you move it anywhere on screen; position is saved to `localStorage` and restored on next open
+- Opens to the bottom-right corner by default when no saved position exists
+- `max-height` + `overflow-y: auto` ensures it never goes off-screen regardless of content length
+- ✕ close button in the drag handle; Escape key still works
+
+**Audio settings restored**
+- Audio section (Microphone, Noise Suppression, Echo Cancellation, Auto Gain Control) was being hidden by the panel going off the top of the viewport; fixed by the panel position rework above
+
+---
+
 ## v0.12.0 — 2026-03-28
 
 ### Feat: video embeds, camera selection, device properties, paste fix, link font

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,37 @@
 # Release Notes
 
+## v0.12.0 — 2026-03-28
+
+### Feat: video embeds, camera selection, device properties, paste fix, link font
+
+**Video link embedding**
+- YouTube (`youtube.com`, `youtu.be`) and Vimeo links sent in chat auto-render as embedded iframes below the link
+- Uses `youtube-nocookie.com` for YouTube privacy; embeds are lazy-loaded at 16:9 aspect ratio
+
+**Camera source selection**
+- Settings panel (⚙️) now includes a Camera dropdown — pick from any connected camera before or between streams
+- Also includes a Microphone dropdown for selecting the active input device
+- Dropdowns populate on load and refresh with device labels after permissions are granted
+- `devicechange` events keep the list current if you plug/unplug a device mid-session
+
+**Camera picker on Start Camera**
+- Clicking "Start Camera" now shows an inline popup listing all available cameras when more than one is detected — click to choose and start
+- Single-camera machines skip the picker and start immediately
+
+**Live camera property sliders**
+- After starting the camera, a "Camera Properties" section appears in the settings panel with sliders for any device-supported properties: brightness, contrast, saturation, sharpness, zoom, exposure time
+- Changes apply live via `track.applyConstraints()` with no need to restart the stream
+- Section is hidden automatically if the browser or device exposes no adjustable properties
+
+**Fix: text paste broken in chat**
+- Plain text paste was being swallowed by the async Clipboard API fallback — it called `event.preventDefault()` before confirming an image was found, blocking all text paste
+- Fixed: the fallback now checks for `text/plain` / `text/html` in `clipboardData.items` first and skips the async path if text content is present
+
+**Fix: chat link font size**
+- Links in chat messages are now rendered 1px larger (14px vs the inherited 13px body text) for easier tap/click targets
+
+---
+
 ## v0.11.3 — 2026-03-27
 
 ### Fix: invite button not updating when friend comes online

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "0.11.3",
+      "version": "0.12.0",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/web/editor-src/index.js
+++ b/src/web/editor-src/index.js
@@ -206,9 +206,11 @@ export function createChatEditor({ editableEl, onSubmit }) {
         }
       }
     }
-    // 3. Async Clipboard API fallback (Electron screenshots often land here)
-    if (navigator.clipboard?.read) {
-      event.preventDefault();
+    // 3. Async Clipboard API fallback (Electron screenshots often land here).
+    // Only attempt this when items was empty/unavailable — if items has text content
+    // we must let the default paste proceed instead of blocking it.
+    const hasTextInItems = Array.from(items || []).some(i => i.type === 'text/plain' || i.type === 'text/html');
+    if (!hasTextInItems && navigator.clipboard?.read) {
       navigator.clipboard.read().then(clipItems => {
         for (const ci of clipItems) {
           const imgType = ci.types.find(t => t.startsWith('image/'));
@@ -220,7 +222,8 @@ export function createChatEditor({ editableEl, onSubmit }) {
           }
         }
       }).catch(() => {});
-      return true;
+      // Don't preventDefault here — if no image is found the paste falls through naturally
+      return false;
     }
     return false;
   }

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -124,31 +124,37 @@
                         <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.49.49 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 0 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1 1 12 8.4a3.6 3.6 0 0 1 0 7.2z"/></svg>
                     </button>
                     <div id="settings-panel" style="display:none">
-                        <h5 class="settings-header">Audio</h5>
-                        <div class="setting-row">
-                            <label for="mic-select" class="setting-label">Microphone</label>
-                            <select id="mic-select" class="setting-select"></select>
+                        <div class="settings-drag-handle" id="settings-drag-handle">
+                            <span>Settings</span>
+                            <button class="settings-close-btn" id="settings-close-btn" aria-label="Close settings">✕</button>
                         </div>
-                        <div class="setting-row">
-                            <span>Noise Suppression</span>
-                            <label class="toggle"><input type="checkbox" id="toggle-ns" checked><span class="toggle-track"><span class="toggle-thumb"></span></span></label>
-                        </div>
-                        <div class="setting-row">
-                            <span>Echo Cancellation</span>
-                            <label class="toggle"><input type="checkbox" id="toggle-ec" checked><span class="toggle-track"><span class="toggle-thumb"></span></span></label>
-                        </div>
-                        <div class="setting-row">
-                            <span>Auto Gain Control</span>
-                            <label class="toggle"><input type="checkbox" id="toggle-agc" checked><span class="toggle-track"><span class="toggle-thumb"></span></span></label>
-                        </div>
-                        <h5 class="settings-header" style="margin-top:var(--sp-md)">Video</h5>
-                        <div class="setting-row">
-                            <label for="camera-select" class="setting-label">Camera</label>
-                            <select id="camera-select" class="setting-select"></select>
-                        </div>
-                        <div id="camera-props" style="display:none">
-                            <h5 class="settings-header" style="margin-top:var(--sp-sm)">Camera Properties</h5>
-                            <div id="camera-props-sliders"></div>
+                        <div class="settings-panel-body">
+                            <h5 class="settings-header">Audio</h5>
+                            <div class="setting-row">
+                                <label for="mic-select" class="setting-label">Microphone</label>
+                                <select id="mic-select" class="setting-select"></select>
+                            </div>
+                            <div class="setting-row">
+                                <span>Noise Suppression</span>
+                                <label class="toggle"><input type="checkbox" id="toggle-ns" checked><span class="toggle-track"><span class="toggle-thumb"></span></span></label>
+                            </div>
+                            <div class="setting-row">
+                                <span>Echo Cancellation</span>
+                                <label class="toggle"><input type="checkbox" id="toggle-ec" checked><span class="toggle-track"><span class="toggle-thumb"></span></span></label>
+                            </div>
+                            <div class="setting-row">
+                                <span>Auto Gain Control</span>
+                                <label class="toggle"><input type="checkbox" id="toggle-agc" checked><span class="toggle-track"><span class="toggle-thumb"></span></span></label>
+                            </div>
+                            <h5 class="settings-header" style="margin-top:var(--sp-md)">Video</h5>
+                            <div class="setting-row">
+                                <label for="camera-select" class="setting-label">Camera</label>
+                                <select id="camera-select" class="setting-select"></select>
+                            </div>
+                            <div id="camera-props" style="display:none">
+                                <h5 class="settings-header" style="margin-top:var(--sp-sm)">Camera Properties</h5>
+                                <div id="camera-props-sliders"></div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -192,6 +198,20 @@
             </div>
         </section>
     </main>
+
+<!-- Camera source picker modal -->
+<div id="camera-picker-modal" class="modal-overlay" style="display:none" role="dialog" aria-modal="true" aria-label="Select Camera">
+    <div class="modal-pane">
+        <div class="modal-pane-header">
+            <span class="modal-pane-title">Select Camera</span>
+            <button class="modal-close-btn" id="camera-picker-close" aria-label="Close">✕</button>
+        </div>
+        <div id="camera-picker-list" class="camera-picker-list"></div>
+        <div class="modal-pane-footer">
+            <button class="btn-ghost" id="camera-picker-cancel">Cancel</button>
+        </div>
+    </div>
+</div>
 
 <script src="/socket.io/socket.io.js"></script>
 <script type="module" src="/js/main.js"></script>

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -124,7 +124,11 @@
                         <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.49.49 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 0 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6A3.6 3.6 0 1 1 12 8.4a3.6 3.6 0 0 1 0 7.2z"/></svg>
                     </button>
                     <div id="settings-panel" style="display:none">
-                        <h5 class="settings-header">Audio Settings</h5>
+                        <h5 class="settings-header">Audio</h5>
+                        <div class="setting-row">
+                            <label for="mic-select" class="setting-label">Microphone</label>
+                            <select id="mic-select" class="setting-select"></select>
+                        </div>
                         <div class="setting-row">
                             <span>Noise Suppression</span>
                             <label class="toggle"><input type="checkbox" id="toggle-ns" checked><span class="toggle-track"><span class="toggle-thumb"></span></span></label>
@@ -136,6 +140,15 @@
                         <div class="setting-row">
                             <span>Auto Gain Control</span>
                             <label class="toggle"><input type="checkbox" id="toggle-agc" checked><span class="toggle-track"><span class="toggle-thumb"></span></span></label>
+                        </div>
+                        <h5 class="settings-header" style="margin-top:var(--sp-md)">Video</h5>
+                        <div class="setting-row">
+                            <label for="camera-select" class="setting-label">Camera</label>
+                            <select id="camera-select" class="setting-select"></select>
+                        </div>
+                        <div id="camera-props" style="display:none">
+                            <h5 class="settings-header" style="margin-top:var(--sp-sm)">Camera Properties</h5>
+                            <div id="camera-props-sliders"></div>
                         </div>
                     </div>
                 </div>

--- a/src/web/public/js/chat-editor.js
+++ b/src/web/public/js/chat-editor.js
@@ -34021,8 +34021,8 @@ function createChatEditor({ editableEl, onSubmit }) {
         }
       }
     }
-    if (navigator.clipboard?.read) {
-      event.preventDefault();
+    const hasTextInItems = Array.from(items || []).some((i) => i.type === "text/plain" || i.type === "text/html");
+    if (!hasTextInItems && navigator.clipboard?.read) {
       navigator.clipboard.read().then((clipItems) => {
         for (const ci of clipItems) {
           const imgType = ci.types.find((t) => t.startsWith("image/"));
@@ -34035,7 +34035,7 @@ function createChatEditor({ editableEl, onSubmit }) {
         }
       }).catch(() => {
       });
-      return true;
+      return false;
     }
     return false;
   }

--- a/src/web/public/js/chat.js
+++ b/src/web/public/js/chat.js
@@ -345,6 +345,8 @@ function addMessageToChat(username, html, text, msgId) {
 
     if (isOwn) msg.querySelector('.msg-header').appendChild(buildControls(id, true));
 
+    embedVideoLinks(msg.querySelector('.msg-body'));
+
     const bar = document.createElement('div');
     bar.className = 'msg-reactions';
     attachReactionTrigger(bar, id);
@@ -414,6 +416,45 @@ function addFileToChat(username, { filename, mimeType, data, size, msgId }) {
     msg.appendChild(bar);
     messagesDiv.appendChild(msg);
     messagesDiv.scrollTop = messagesDiv.scrollHeight;
+}
+
+// ── Video link embedding ──
+function getVideoEmbedSrc(url) {
+    try {
+        const u = new URL(url);
+        const host = u.hostname.replace(/^www\./, '');
+        // YouTube
+        if (host === 'youtube.com' || host === 'youtube-nocookie.com') {
+            const v = u.searchParams.get('v');
+            if (v) return `https://www.youtube-nocookie.com/embed/${encodeURIComponent(v)}`;
+        }
+        if (host === 'youtu.be') {
+            const v = u.pathname.slice(1).split('/')[0];
+            if (v) return `https://www.youtube-nocookie.com/embed/${encodeURIComponent(v)}`;
+        }
+        // Vimeo
+        if (host === 'vimeo.com') {
+            const m = u.pathname.match(/^\/(\d+)/);
+            if (m) return `https://player.vimeo.com/video/${m[1]}`;
+        }
+    } catch { /* ignore malformed URLs */ }
+    return null;
+}
+
+function embedVideoLinks(bodyEl) {
+    bodyEl.querySelectorAll('a[href]').forEach(a => {
+        const src = getVideoEmbedSrc(a.href);
+        if (!src) return;
+        const wrapper = document.createElement('div');
+        wrapper.className = 'chat-video-embed';
+        const iframe = document.createElement('iframe');
+        iframe.src = src;
+        iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+        iframe.allowFullscreen = true;
+        iframe.loading = 'lazy';
+        wrapper.appendChild(iframe);
+        a.parentNode.insertBefore(wrapper, a.nextSibling);
+    });
 }
 
 // ── Image lightbox ──

--- a/src/web/public/js/main.js
+++ b/src/web/public/js/main.js
@@ -35,7 +35,7 @@ if (isInRoom()) {
         leaveAudio();
     });
 
-    // Start Camera — shows picker if multiple cameras available
+    // Start Camera — shows picker modal if multiple cameras available
     const startCameraBtn = document.getElementById('start-camera');
 
     async function launchCamera() {
@@ -49,54 +49,40 @@ if (isInRoom()) {
         startCameraBtn.disabled = false;
     }
 
-    function showCameraPickerPopup(cameras) {
-        // Remove any existing popup
-        document.getElementById('camera-picker-popup')?.remove();
+    function showCameraPickerModal(cameras) {
+        const modal = document.getElementById('camera-picker-modal');
+        const list  = document.getElementById('camera-picker-list');
+        if (!modal || !list) return;
 
-        const popup = document.createElement('div');
-        popup.id = 'camera-picker-popup';
-        popup.className = 'camera-picker-popup';
-        popup.style.position = 'fixed';
-
-        const title = document.createElement('h6');
-        title.textContent = 'Select Camera';
-        popup.appendChild(title);
-
-        for (const cam of cameras) {
+        list.innerHTML = '';
+        cameras.forEach((cam, i) => {
             const btn = document.createElement('button');
             btn.className = 'camera-picker-option';
-            btn.textContent = cam.label || `Camera ${cameras.indexOf(cam) + 1}`;
+            btn.innerHTML =
+                `<span class="camera-picker-option-icon">📷</span>` +
+                `<span class="camera-picker-option-name">${cam.label || `Camera ${i + 1}`}</span>`;
             btn.addEventListener('click', () => {
                 const sel = document.getElementById('camera-select');
                 if (sel) sel.value = cam.deviceId;
-                popup.remove();
+                closeCameraModal();
                 launchCamera();
             });
-            popup.appendChild(btn);
-        }
+            list.appendChild(btn);
+        });
 
-        document.body.appendChild(popup);
-
-        // Position above button
-        const rect = startCameraBtn.getBoundingClientRect();
-        const pw = popup.offsetWidth || 180;
-        const ph = popup.offsetHeight || 80;
-        let left = rect.left + rect.width / 2 - pw / 2;
-        let top  = rect.top - ph - 8;
-        if (top < 8) top = rect.bottom + 8;
-        left = Math.max(8, Math.min(left, window.innerWidth - pw - 8));
-        popup.style.left = left + 'px';
-        popup.style.top  = top  + 'px';
-
-        // Close on outside click
-        function onOutside(e) {
-            if (!popup.contains(e.target) && e.target !== startCameraBtn) {
-                popup.remove();
-                document.removeEventListener('click', onOutside, true);
-            }
-        }
-        setTimeout(() => document.addEventListener('click', onOutside, true), 0);
+        modal.style.display = 'flex';
     }
+
+    function closeCameraModal() {
+        const modal = document.getElementById('camera-picker-modal');
+        if (modal) modal.style.display = 'none';
+    }
+
+    document.getElementById('camera-picker-close')?.addEventListener('click', closeCameraModal);
+    document.getElementById('camera-picker-cancel')?.addEventListener('click', closeCameraModal);
+    document.getElementById('camera-picker-modal')?.addEventListener('click', (e) => {
+        if (e.target === e.currentTarget) closeCameraModal(); // click backdrop
+    });
 
     startCameraBtn.addEventListener('click', async () => {
         let cameras = [];
@@ -106,7 +92,7 @@ if (isInRoom()) {
         } catch { /* fall through to direct start */ }
 
         if (cameras.length > 1) {
-            showCameraPickerPopup(cameras);
+            showCameraPickerModal(cameras);
         } else {
             launchCamera();
         }
@@ -129,36 +115,80 @@ if (isInRoom()) {
         stopVideo();
     });
 
-    // Settings panel
-    const settingsBtn = document.getElementById('settings-btn');
+    // Settings panel — draggable floating
+    const settingsBtn   = document.getElementById('settings-btn');
     const settingsPanel = document.getElementById('settings-panel');
-    const toggleNS = document.getElementById('toggle-ns');
-    const toggleEC = document.getElementById('toggle-ec');
+    const dragHandle    = document.getElementById('settings-drag-handle');
+    const closeBtn      = document.getElementById('settings-close-btn');
+    const toggleNS  = document.getElementById('toggle-ns');
+    const toggleEC  = document.getElementById('toggle-ec');
     const toggleAGC = document.getElementById('toggle-agc');
 
     // Init checkboxes from saved state
-    toggleNS.checked = state.audioSettings.noiseSuppression;
-    toggleEC.checked = state.audioSettings.echoCancellation;
+    toggleNS.checked  = state.audioSettings.noiseSuppression;
+    toggleEC.checked  = state.audioSettings.echoCancellation;
     toggleAGC.checked = state.audioSettings.autoGainControl;
+
+    function openSettingsPanel() {
+        // Restore last position, or position near the gear button
+        const saved = (() => { try { return JSON.parse(localStorage.getItem('settings-panel-pos')); } catch { return null; } })();
+        if (saved && typeof saved.x === 'number') {
+            settingsPanel.style.left = saved.x + 'px';
+            settingsPanel.style.top  = saved.y + 'px';
+        } else {
+            settingsPanel.style.left = '';
+            settingsPanel.style.top  = '';
+            settingsPanel.style.right  = '16px';
+            settingsPanel.style.bottom = '64px';
+        }
+        settingsPanel.style.display = 'block';
+    }
+
+    function closeSettingsPanel() { settingsPanel.style.display = 'none'; }
 
     settingsBtn.addEventListener('click', (e) => {
         e.stopPropagation();
-        settingsPanel.style.display = settingsPanel.style.display === 'none' ? 'block' : 'none';
+        settingsPanel.style.display === 'none' ? openSettingsPanel() : closeSettingsPanel();
     });
 
-    // Close on click outside
-    document.addEventListener('click', (e) => {
-        if (settingsPanel.style.display !== 'none' && !settingsPanel.contains(e.target) && e.target !== settingsBtn) {
-            settingsPanel.style.display = 'none';
-        }
-    });
+    closeBtn?.addEventListener('click', closeSettingsPanel);
 
-    // Close on Escape
+    // Escape key closes it
     document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && settingsPanel.style.display !== 'none') {
-            settingsPanel.style.display = 'none';
-        }
+        if (e.key === 'Escape' && settingsPanel.style.display !== 'none') closeSettingsPanel();
     });
+
+    // Drag
+    let dragging = false, dragOX = 0, dragOY = 0;
+    dragHandle?.addEventListener('mousedown', (e) => {
+        if (e.target.closest('.settings-close-btn')) return;
+        dragging = true;
+        const r = settingsPanel.getBoundingClientRect();
+        dragOX = e.clientX - r.left;
+        dragOY = e.clientY - r.top;
+        // Switch from right/bottom anchoring to explicit left/top once dragged
+        settingsPanel.style.right  = '';
+        settingsPanel.style.bottom = '';
+        settingsPanel.style.left   = r.left + 'px';
+        settingsPanel.style.top    = r.top  + 'px';
+        document.addEventListener('mousemove', onDragMove);
+        document.addEventListener('mouseup',   onDragUp);
+    });
+    function onDragMove(e) {
+        if (!dragging) return;
+        const pw = settingsPanel.offsetWidth;
+        const ph = settingsPanel.offsetHeight;
+        const x = Math.max(0, Math.min(e.clientX - dragOX, window.innerWidth  - pw));
+        const y = Math.max(0, Math.min(e.clientY - dragOY, window.innerHeight - ph));
+        settingsPanel.style.left = x + 'px';
+        settingsPanel.style.top  = y + 'px';
+        try { localStorage.setItem('settings-panel-pos', JSON.stringify({ x, y })); } catch { /* ignore */ }
+    }
+    function onDragUp() {
+        dragging = false;
+        document.removeEventListener('mousemove', onDragMove);
+        document.removeEventListener('mouseup',   onDragUp);
+    }
 
     // Toggle handlers
     async function handleToggle(checkbox, key) {

--- a/src/web/public/js/main.js
+++ b/src/web/public/js/main.js
@@ -1,4 +1,4 @@
-import { initCamera, shareScreen, initAudio, leaveAudio, stopVideo, reapplyAudioSettings } from './media.js';
+import { initCamera, shareScreen, initAudio, leaveAudio, stopVideo, reapplyAudioSettings, populateDeviceSelects, refreshDeviceLabels } from './media.js';
 import { setupSignalingListeners } from './webrtc.js';
 import { setupChatListeners } from './chat.js';
 import { setupUIListeners } from './ui.js';
@@ -13,6 +13,10 @@ setupUIListeners();
 
 // Only initialize call features when inside a room
 if (isInRoom()) {
+    // Populate device dropdowns; re-populate after first permission grant so labels appear
+    populateDeviceSelects();
+    navigator.mediaDevices?.addEventListener('devicechange', () => populateDeviceSelects());
+
     // Join Audio
     document.getElementById('join-audio-btn').addEventListener('click', async () => {
         const btn = document.getElementById('join-audio-btn');
@@ -20,6 +24,7 @@ if (isInRoom()) {
         btn.textContent = 'Joining...';
         try {
             await initAudio();
+            refreshDeviceLabels();
         } catch { /* handled in initAudio */ }
         btn.textContent = 'Join Audio';
         btn.disabled = false;
@@ -30,16 +35,81 @@ if (isInRoom()) {
         leaveAudio();
     });
 
-    // Start Camera
+    // Start Camera — shows picker if multiple cameras available
     const startCameraBtn = document.getElementById('start-camera');
-    startCameraBtn.addEventListener('click', async () => {
+
+    async function launchCamera() {
         startCameraBtn.disabled = true;
         startCameraBtn.textContent = 'Starting...';
         try {
             await initCamera();
+            refreshDeviceLabels();
         } catch { /* handled in initCamera */ }
         startCameraBtn.textContent = 'Start Camera';
         startCameraBtn.disabled = false;
+    }
+
+    function showCameraPickerPopup(cameras) {
+        // Remove any existing popup
+        document.getElementById('camera-picker-popup')?.remove();
+
+        const popup = document.createElement('div');
+        popup.id = 'camera-picker-popup';
+        popup.className = 'camera-picker-popup';
+        popup.style.position = 'fixed';
+
+        const title = document.createElement('h6');
+        title.textContent = 'Select Camera';
+        popup.appendChild(title);
+
+        for (const cam of cameras) {
+            const btn = document.createElement('button');
+            btn.className = 'camera-picker-option';
+            btn.textContent = cam.label || `Camera ${cameras.indexOf(cam) + 1}`;
+            btn.addEventListener('click', () => {
+                const sel = document.getElementById('camera-select');
+                if (sel) sel.value = cam.deviceId;
+                popup.remove();
+                launchCamera();
+            });
+            popup.appendChild(btn);
+        }
+
+        document.body.appendChild(popup);
+
+        // Position above button
+        const rect = startCameraBtn.getBoundingClientRect();
+        const pw = popup.offsetWidth || 180;
+        const ph = popup.offsetHeight || 80;
+        let left = rect.left + rect.width / 2 - pw / 2;
+        let top  = rect.top - ph - 8;
+        if (top < 8) top = rect.bottom + 8;
+        left = Math.max(8, Math.min(left, window.innerWidth - pw - 8));
+        popup.style.left = left + 'px';
+        popup.style.top  = top  + 'px';
+
+        // Close on outside click
+        function onOutside(e) {
+            if (!popup.contains(e.target) && e.target !== startCameraBtn) {
+                popup.remove();
+                document.removeEventListener('click', onOutside, true);
+            }
+        }
+        setTimeout(() => document.addEventListener('click', onOutside, true), 0);
+    }
+
+    startCameraBtn.addEventListener('click', async () => {
+        let cameras = [];
+        try {
+            const devices = await navigator.mediaDevices.enumerateDevices();
+            cameras = devices.filter(d => d.kind === 'videoinput');
+        } catch { /* fall through to direct start */ }
+
+        if (cameras.length > 1) {
+            showCameraPickerPopup(cameras);
+        } else {
+            launchCamera();
+        }
     });
 
     // Share Screen

--- a/src/web/public/js/media.js
+++ b/src/web/public/js/media.js
@@ -32,11 +32,16 @@ function getElectronDesktopConstraints(sourceId) {
 
 export function getVideoConstraints() {
     const val = document.getElementById('resolution-select').value;
-    if (val === 'native') {
-        return true;
-    }
-    const [w, h] = val.split('x').map(Number);
-    return { width: { ideal: w }, height: { ideal: h } };
+    const deviceId = document.getElementById('camera-select')?.value;
+    const base = val === 'native'
+        ? {}
+        : { width: { ideal: Number(val.split('x')[0]) }, height: { ideal: Number(val.split('x')[1]) } };
+    if (deviceId) base.deviceId = { exact: deviceId };
+    return Object.keys(base).length ? base : true;
+}
+
+function getAudioDeviceId() {
+    return document.getElementById('mic-select')?.value || undefined;
 }
 
 function broadcastMediaState() {
@@ -49,11 +54,14 @@ function hasAnyMedia() {
 }
 
 function getAudioConstraints() {
-    return {
+    const c = {
         noiseSuppression: state.audioSettings.noiseSuppression,
         echoCancellation: state.audioSettings.echoCancellation,
         autoGainControl: state.audioSettings.autoGainControl
     };
+    const deviceId = getAudioDeviceId();
+    if (deviceId) c.deviceId = { exact: deviceId };
+    return c;
 }
 
 // Join audio — mic only
@@ -134,6 +142,7 @@ export async function initCamera() {
 
         state.media.video = true;
         broadcastMediaState();
+        buildCameraProps(videoTrack);
     } catch (error) {
         console.error('Error accessing camera:', error);
         alert(formatMediaError('Could not access camera', error));
@@ -285,4 +294,103 @@ export async function reapplyAudioSettings() {
 export function stopCamera() {
     stopVideo();
     leaveAudio();
+}
+
+// ── Camera device properties (brightness, contrast, zoom, etc.) ──
+const CAMERA_PROP_LABELS = {
+    brightness:  'Brightness',
+    contrast:    'Contrast',
+    saturation:  'Saturation',
+    sharpness:   'Sharpness',
+    zoom:        'Zoom',
+    exposureTime:'Exposure Time',
+    whiteBalanceMode: null, // skip — non-numeric
+    focusMode:   null,      // skip — non-numeric
+};
+
+function buildCameraProps(track) {
+    const container = document.getElementById('camera-props');
+    const slidersEl = document.getElementById('camera-props-sliders');
+    if (!container || !slidersEl) return;
+
+    slidersEl.innerHTML = '';
+
+    const caps = track.getCapabilities?.();
+    if (!caps) { container.style.display = 'none'; return; }
+
+    let count = 0;
+    for (const [prop, label] of Object.entries(CAMERA_PROP_LABELS)) {
+        if (!label || !(prop in caps)) continue;
+        const range = caps[prop];
+        if (typeof range.min !== 'number' || typeof range.max !== 'number' || range.min === range.max) continue;
+
+        const current = track.getSettings?.()?.[prop] ?? range.min;
+        count++;
+
+        const row = document.createElement('div');
+        row.className = 'camera-prop-row';
+
+        const labelRow = document.createElement('div');
+        labelRow.className = 'camera-prop-label';
+        const nameEl = document.createElement('span');
+        nameEl.textContent = label;
+        const valEl = document.createElement('span');
+        valEl.textContent = Number(current).toFixed(range.step < 1 ? 2 : 0);
+        labelRow.appendChild(nameEl);
+        labelRow.appendChild(valEl);
+
+        const slider = document.createElement('input');
+        slider.type = 'range';
+        slider.className = 'camera-prop-slider';
+        slider.min = range.min;
+        slider.max = range.max;
+        slider.step = range.step ?? 1;
+        slider.value = current;
+
+        slider.addEventListener('input', () => {
+            const v = Number(slider.value);
+            valEl.textContent = v.toFixed(range.step < 1 ? 2 : 0);
+            track.applyConstraints({ advanced: [{ [prop]: v }] }).catch(() => {});
+        });
+
+        row.appendChild(labelRow);
+        row.appendChild(slider);
+        slidersEl.appendChild(row);
+    }
+
+    container.style.display = count > 0 ? 'block' : 'none';
+}
+
+// Enumerate cameras and mics; populate the dropdowns in the settings panel
+export async function populateDeviceSelects() {
+    try {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const cameraSelect = document.getElementById('camera-select');
+        const micSelect = document.getElementById('mic-select');
+        if (!cameraSelect || !micSelect) return;
+
+        const cameras = devices.filter(d => d.kind === 'videoinput');
+        const mics    = devices.filter(d => d.kind === 'audioinput');
+
+        cameraSelect.innerHTML = cameras.length === 0 ? '<option value="">No cameras found</option>' : '';
+        for (const cam of cameras) {
+            const opt = document.createElement('option');
+            opt.value = cam.deviceId;
+            opt.textContent = cam.label || `Camera ${cameraSelect.options.length + 1}`;
+            cameraSelect.appendChild(opt);
+        }
+
+        micSelect.innerHTML = mics.length === 0 ? '<option value="">No mics found</option>' : '';
+        for (const mic of mics) {
+            const opt = document.createElement('option');
+            opt.value = mic.deviceId;
+            opt.textContent = mic.label || `Microphone ${micSelect.options.length + 1}`;
+            micSelect.appendChild(opt);
+        }
+    } catch { /* permissions not yet granted — dropdowns stay empty until first use */ }
+}
+
+// After permissions granted, re-populate (labels become available)
+export function refreshDeviceLabels() {
+    populateDeviceSelects().catch(() => {});
 }

--- a/src/web/public/main.css
+++ b/src/web/public/main.css
@@ -637,6 +637,96 @@ body{
     margin-top: var(--sp-xs);
 }
 
+.setting-label{
+    font-size: var(--text-sm);
+    color: var(--c-text);
+    flex-shrink: 0;
+    margin-right: var(--sp-sm);
+}
+
+.setting-select{
+    flex: 1;
+    min-width: 0;
+    font-size: var(--text-xs);
+    font-family: var(--font-sans);
+    background: var(--c-base);
+    color: var(--c-text);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-sm);
+    padding: 3px 6px;
+    max-width: 140px;
+}
+.setting-select:focus{
+    outline: none;
+    border-color: var(--c-accent);
+}
+
+/* ── Camera picker popup ── */
+.camera-picker-popup{
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--c-elevated);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-md);
+    box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+    padding: var(--sp-sm);
+    z-index: 200;
+    min-width: 180px;
+}
+.camera-picker-popup h6{
+    margin: 0 0 var(--sp-xs);
+    font-size: var(--text-xs);
+    color: var(--c-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    font-weight: 600;
+    font-family: var(--font-mono);
+}
+.camera-picker-option{
+    display: block;
+    width: 100%;
+    text-align: left;
+    background: none;
+    border: none;
+    color: var(--c-text);
+    font-size: var(--text-sm);
+    font-family: var(--font-sans);
+    padding: 5px var(--sp-xs);
+    border-radius: var(--r-sm);
+    cursor: pointer;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 220px;
+}
+.camera-picker-option:hover{
+    background: var(--c-accent-muted);
+    color: var(--c-accent);
+}
+
+.camera-prop-row{
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 4px 0;
+    border-top: 1px solid var(--c-border-subtle);
+}
+.camera-prop-row:first-child{ border-top: none; }
+.camera-prop-label{
+    display: flex;
+    justify-content: space-between;
+    font-size: var(--text-xs);
+    color: var(--c-text-secondary);
+}
+.camera-prop-label span:last-child{ color: var(--c-accent); font-family: var(--font-mono); }
+.camera-prop-slider{
+    width: 100%;
+    accent-color: var(--c-accent);
+    cursor: pointer;
+}
+
 /* ── Toggle switch ── */
 .toggle{
     position: relative;
@@ -1208,6 +1298,7 @@ img.chat-inline-img{ cursor: zoom-in; }
 }
 .msg-body a.chat-link{
     color: var(--c-accent);
+    font-size: 14px;
     text-decoration: underline;
     text-decoration-color: rgba(173,255,47,0.4);
 }
@@ -1217,6 +1308,21 @@ img.chat-inline-img{ cursor: zoom-in; }
     margin: var(--sp-xs) 0;
 }
 .msg-body li{ margin: 1px 0; }
+.chat-video-embed{
+    margin: var(--sp-xs) 0;
+    border-radius: var(--r-sm);
+    overflow: hidden;
+    border: 1px solid var(--c-border-subtle);
+    background: var(--c-base);
+    max-width: 400px;
+    aspect-ratio: 16/9;
+}
+.chat-video-embed iframe{
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: none;
+}
 .msg-body img.chat-inline-img{
     display: block;
     max-width: 280px;

--- a/src/web/public/main.css
+++ b/src/web/public/main.css
@@ -583,11 +583,7 @@ body{
     opacity: 0.85;
 }
 
-/* ── Settings panel ── */
-#settings-panel-anchor{
-    position: relative;
-}
-
+/* ── Settings panel (draggable floating) ── */
 #settings-btn{
     display: flex;
     align-items: center;
@@ -595,17 +591,49 @@ body{
 }
 
 #settings-panel{
-    position: absolute;
-    bottom: calc(100% + var(--sp-sm));
-    left: 50%;
-    transform: translateX(-50%);
-    width: 240px;
-    padding: var(--sp-md);
+    position: fixed;
+    width: 260px;
+    max-height: calc(100vh - 32px);
+    overflow-y: auto;
     background: var(--c-elevated);
     border: 1px solid var(--c-border);
     border-radius: var(--r-md);
-    box-shadow: 0 4px 24px rgba(0,0,0,0.4);
-    z-index: 100;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.55);
+    z-index: 300;
+}
+
+.settings-drag-handle{
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--c-border-subtle);
+    cursor: grab;
+    user-select: none;
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
+    color: var(--c-text-muted);
+    letter-spacing: 1.2px;
+    font-weight: 600;
+    text-transform: uppercase;
+    border-radius: var(--r-md) var(--r-md) 0 0;
+}
+.settings-drag-handle:active{ cursor: grabbing; }
+
+.settings-close-btn{
+    background: none;
+    border: none;
+    color: var(--c-text-muted);
+    font-size: 14px;
+    cursor: pointer;
+    padding: 2px 4px;
+    line-height: 1;
+    border-radius: var(--r-sm);
+}
+.settings-close-btn:hover{ color: var(--c-text); background: var(--c-overlay); }
+
+.settings-panel-body{
+    padding: var(--sp-md);
 }
 
 .settings-header{
@@ -661,50 +689,120 @@ body{
     border-color: var(--c-accent);
 }
 
-/* ── Camera picker popup ── */
-.camera-picker-popup{
-    position: absolute;
-    bottom: calc(100% + 6px);
-    left: 50%;
-    transform: translateX(-50%);
+/* ── Modal overlay (camera picker, etc.) ── */
+.modal-overlay{
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.65);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 500;
+    backdrop-filter: blur(2px);
+}
+
+.modal-pane{
     background: var(--c-elevated);
     border: 1px solid var(--c-border);
-    border-radius: var(--r-md);
-    box-shadow: 0 4px 20px rgba(0,0,0,0.5);
-    padding: var(--sp-sm);
-    z-index: 200;
-    min-width: 180px;
+    border-radius: var(--r-lg);
+    box-shadow: 0 16px 48px rgba(0,0,0,0.7);
+    width: 360px;
+    max-width: calc(100vw - 32px);
+    overflow: hidden;
+    animation: modal-in 150ms ease-out;
 }
-.camera-picker-popup h6{
-    margin: 0 0 var(--sp-xs);
-    font-size: var(--text-xs);
-    color: var(--c-text-muted);
-    text-transform: uppercase;
-    letter-spacing: 1.2px;
+
+@keyframes modal-in{
+    from{ opacity: 0; transform: scale(0.95) translateY(8px); }
+    to{   opacity: 1; transform: scale(1)    translateY(0);   }
+}
+
+.modal-pane-header{
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 14px 16px 12px;
+    border-bottom: 1px solid var(--c-border-subtle);
+}
+
+.modal-pane-title{
+    font-size: var(--text-base);
     font-weight: 600;
-    font-family: var(--font-mono);
+    color: var(--c-text);
 }
-.camera-picker-option{
-    display: block;
-    width: 100%;
-    text-align: left;
+
+.modal-close-btn{
     background: none;
     border: none;
+    color: var(--c-text-muted);
+    font-size: 16px;
+    cursor: pointer;
+    padding: 2px 6px;
+    border-radius: var(--r-sm);
+    line-height: 1;
+}
+.modal-close-btn:hover{ color: var(--c-text); background: var(--c-overlay); }
+
+.camera-picker-list{
+    padding: var(--sp-sm);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.camera-picker-option{
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+    width: 100%;
+    text-align: left;
+    background: var(--c-base);
+    border: 1px solid var(--c-border);
     color: var(--c-text);
     font-size: var(--text-sm);
     font-family: var(--font-sans);
-    padding: 5px var(--sp-xs);
-    border-radius: var(--r-sm);
+    padding: 10px 14px;
+    border-radius: var(--r-md);
     cursor: pointer;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 220px;
+    transition: border-color var(--dur-micro) ease-out,
+                background var(--dur-micro) ease-out;
 }
 .camera-picker-option:hover{
-    background: var(--c-accent-muted);
+    background: var(--c-overlay);
+    border-color: var(--c-accent);
     color: var(--c-accent);
 }
+.camera-picker-option-icon{
+    font-size: 18px;
+    flex-shrink: 0;
+}
+.camera-picker-option-name{
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.modal-pane-footer{
+    padding: 10px 16px;
+    border-top: 1px solid var(--c-border-subtle);
+    display: flex;
+    justify-content: flex-end;
+}
+
+.btn-ghost{
+    background: none;
+    border: 1px solid var(--c-border);
+    color: var(--c-text-secondary);
+    font-size: var(--text-sm);
+    font-family: var(--font-sans);
+    padding: 6px 14px;
+    border-radius: var(--r-sm);
+    cursor: pointer;
+}
+.btn-ghost:hover{ border-color: var(--c-text-secondary); color: var(--c-text); }
 
 .camera-prop-row{
     display: flex;


### PR DESCRIPTION
Summary                                                                                                                                             
                                                                                                                                                      
  - Video link embedding — YouTube and Vimeo links in chat auto-render as embedded players (16:9, lazy-loaded, youtube-nocookie.com for privacy)
  - Camera & mic source selection — Settings panel now includes dropdowns to choose from all connected cameras and microphones; populates on load,
  refreshes labels after permissions are granted and on devicechange
  - Camera picker modal — Clicking "Start Camera" with multiple cameras shows a proper centered modal to pick before starting; single-camera machines 
  skip it
  - Live camera property sliders — After starting camera, sliders appear for any device-supported properties (brightness, contrast, saturation,       
  sharpness, zoom, exposure) and apply live via applyConstraints()
  - Draggable settings panel — Converted from a position: absolute popup (clipped off-screen on most layouts) to a position: fixed floating panel with
   a drag handle; position saved to localStorage
  - Fix: text paste blocked — Async clipboard fallback was calling preventDefault() unconditionally, swallowing all plain-text paste; now skips the   
  async path when text/plain/text/html is present in clipboardData.items
  - Fix: chat link font size — Links in messages bumped 1px larger (14px) for easier click targets

  Test plan

  - Paste plain text into chat — should work; paste a screenshot — should still embed as image
  - Send a YouTube or Vimeo link — embedded player should appear below the link
  - Open settings (⚙️), verify Audio section (mic dropdown + NS/EC/AGC toggles) and Video section (camera dropdown) are both visible and scrollable   
  - Drag the settings panel to a new position, close and reopen — should restore to saved position
  - With multiple cameras: click "Start Camera" → picker modal appears; select one → camera starts with that device
  - With one camera: click "Start Camera" → starts immediately, no modal
  - After starting camera, open settings — Camera Properties sliders should appear if the device/browser exposes capabilities
  - Verify links in chat render visibly larger than surrounding body text