### PR TITLE
feat(electron): persist server URL to client.json after successful connection

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v0.14.1 — 2026-03-28
+
+### Feat: persist server URL after successful Electron connection
+
+- After manually connecting to a server, the URL is written back to `config/client.json`
+- App auto-connects on next launch without showing the connection dialog
+
+---
+
 ## v0.13.3 — 2026-03-28
 
 ### Fix: disable invite button when friend is already in the room

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/desktop/main.js
+++ b/src/desktop/main.js
@@ -264,7 +264,11 @@ function attemptConnect(url) {
 }
 
 ipcMain.handle('connect-to-server', async (_event, url) => {
-    return attemptConnect(url);
+    await attemptConnect(url);
+    try {
+        clientConfig.serverUrl = url;
+        fs.writeFileSync(clientConfigPath, JSON.stringify(clientConfig, null, 2));
+    } catch { /* ignore write errors */ }
 });
 
 ipcMain.handle('get-default-server-url', () => {


### PR DESCRIPTION
Feat: persist server URL after successful Electron connection                                                                                                              

* After manually connecting to a server, the URL is written back to `config/client.json`
* App auto-connects on next launch without showing the connection dialog