### PR TITLE
fix(media): strip camera deviceId from getDisplayMedia constraints in browser

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v0.14.2 — 2026-03-28
+
+### Fix: browser screen share failing with exact constraints error
+
+- `getDisplayMedia` does not support `exact` constraints — the camera `deviceId` was being passed through and causing a TypeError
+- Screen share in the browser now uses resolution-only constraints, stripping the device ID
+
+---
+
 ## v0.14.1 — 2026-03-28
 
 ### Feat: persist server URL after successful Electron connection

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/web/public/js/media.js
+++ b/src/web/public/js/media.js
@@ -187,8 +187,12 @@ export async function shareScreen() {
                 });
             }
         } else {
+            const val = document.getElementById('resolution-select').value;
+            const videoConstraints = val === 'native'
+                ? true
+                : { width: { ideal: Number(val.split('x')[0]) }, height: { ideal: Number(val.split('x')[1]) } };
             newStream = await navigator.mediaDevices.getDisplayMedia({
-                video: getVideoConstraints(),
+                video: videoConstraints,
                 audio: true
             });
         }


### PR DESCRIPTION
Fix: browser screen share failing with exact constraints error                                                                                                             
* `getDisplayMedia` does not support `exact` constraints — the camera `deviceId` was being passed through and causing a TypeError
* Screen share in the browser now uses resolution-only constraints, stripping the device ID