### PR TITLE
fix(electron): save server URL to userData dir so it persists in packaged app

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v0.14.3 — 2026-03-28
+
+### Fix: Electron server URL not persisting across restarts
+
+- `config/client.json` inside the app bundle is read-only when installed — writes were silently failing
+- Server URL is now saved to the OS user data directory (`%APPDATA%\FreeRTC\` on Windows) which is always writable
+- Dev mode still seeds the initial URL from `config/client.json` in the project root
+
+---
+
 ## v0.14.2 — 2026-03-28
 
 ### Fix: browser screen share failing with exact constraints error

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/desktop/main.js
+++ b/src/desktop/main.js
@@ -16,11 +16,21 @@ const appIcon = fs.existsSync(iconPath)
     })();
 
 // Load client config (serverUrl)
-const clientConfigPath = path.join(__dirname, '../../config/client.json');
-const clientConfig = (() => {
-    try { return JSON.parse(fs.readFileSync(clientConfigPath, 'utf8')); }
-    catch { return {}; }
-})();
+// Prefer userData dir (writable in packaged app); fall back to source tree for dev
+function getClientConfigPath() {
+    try { return path.join(app.getPath('userData'), 'client.json'); }
+    catch { return path.join(__dirname, '../../config/client.json'); }
+}
+function loadClientConfig() {
+    const p = getClientConfigPath();
+    try { return JSON.parse(fs.readFileSync(p, 'utf8')); }
+    catch {
+        // Fall back to source-tree config.json (dev mode seed value)
+        try { return JSON.parse(fs.readFileSync(path.join(__dirname, '../../config/client.json'), 'utf8')); }
+        catch { return {}; }
+    }
+}
+let clientConfig = {};
 
 let mainWindow = null;
 let connectionWindow = null;
@@ -267,7 +277,7 @@ ipcMain.handle('connect-to-server', async (_event, url) => {
     await attemptConnect(url);
     try {
         clientConfig.serverUrl = url;
-        fs.writeFileSync(clientConfigPath, JSON.stringify(clientConfig, null, 2));
+        fs.writeFileSync(getClientConfigPath(), JSON.stringify(clientConfig, null, 2));
     } catch { /* ignore write errors */ }
 });
 
@@ -289,6 +299,8 @@ ipcMain.handle('pick-display-source', async () => {
 });
 
 app.whenReady().then(async () => {
+    clientConfig = loadClientConfig();
+
     if (process.platform === 'darwin' && app.dock) {
         app.dock.setIcon(appIcon);
     }


### PR DESCRIPTION
Fix: Electron server URL not persisting across restarts                                                                                                                    
* `config/client.json` inside the app bundle is read-only when installed — writes were silently failing                                                                        
* Server URL is now saved to the OS user data directory (`%APPDATA%\FreeRTC\` on Windows) which is always writable                                                             
* Dev mode still seeds the initial URL from `config/client.json` in the project root 