### PR TITLE
feat(electron): structured logging with configurable level via client.json , add log level to gui menu

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## v0.14.4 — 2026-03-29
+
+### Feat: structured logging for Electron desktop client
+
+- Log file written to `%APPDATA%\FreeRTC\freertc.log` (writable in packaged app)
+- Four levels: `debug`, `info`, `warn`, `error` — configurable via `logLevel` in `client.json`
+- Logs connection attempts, auto-connect results, config saves, window lifecycle, display picker, permission checks, renderer crashes, and uncaught exceptions
+- Log file accessible from **Help → Open Log File**
+- Log level changeable at runtime from **Help → Log Level** — selection is saved to `client.json` and persists across restarts
+
+---
+
 ## v0.14.3 — 2026-03-28
 
 ### Fix: Electron server URL not persisting across restarts

--- a/config/client.json
+++ b/config/client.json
@@ -1,3 +1,4 @@
 {
-  "serverUrl": ""
+  "serverUrl": "https://<server_host>:<server_port>",
+  "logLevel": "info"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/desktop/main.js
+++ b/src/desktop/main.js
@@ -4,34 +4,70 @@ const path = require('path');
 const fs = require('fs');
 const https = require('https');
 
-// Load icon from file when available, otherwise use a white placeholder
-const iconPath = path.join(__dirname, '../web/public/icon.png');
-const appIcon = fs.existsSync(iconPath)
-    ? nativeImage.createFromPath(iconPath)
-    : (() => {
-        // 32x32 white RGBA buffer
-        const size = 32;
-        const buf = Buffer.alloc(size * size * 4, 255); // all 0xFF = opaque white
-        return nativeImage.createFromBuffer(buf, { width: size, height: size });
-    })();
+// ── Logger ────────────────────────────────────────────────────────────────────
+// Levels: debug < info < warn < error
+// Configured via logLevel in client.json. Defaults to 'info'.
+const LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
 
-// Load client config (serverUrl)
+const logger = (() => {
+    let logPath = null;
+    let minLevel = 1; // info
+
+    function getPath() {
+        if (!logPath) {
+            try { logPath = path.join(app.getPath('userData'), 'freertc.log'); }
+            catch { logPath = path.join(__dirname, '../../freertc.log'); }
+        }
+        return logPath;
+    }
+
+    function write(level, ...args) {
+        if (LEVELS[level] < minLevel) return;
+        const line = `[${new Date().toISOString()}] [${level.toUpperCase()}] ${args.join(' ')}\n`;
+        process.stdout.write(line);
+        try { fs.appendFileSync(getPath(), line); } catch { /* ignore */ }
+    }
+
+    return {
+        setLevel: (level) => { minLevel = LEVELS[level] ?? 1; },
+        debug: (...a) => write('debug', ...a),
+        info:  (...a) => write('info',  ...a),
+        warn:  (...a) => write('warn',  ...a),
+        error: (...a) => write('error', ...a),
+        path:  ()     => getPath()
+    };
+})();
+
+// ── Client config ─────────────────────────────────────────────────────────────
 // Prefer userData dir (writable in packaged app); fall back to source tree for dev
 function getClientConfigPath() {
     try { return path.join(app.getPath('userData'), 'client.json'); }
     catch { return path.join(__dirname, '../../config/client.json'); }
 }
+
 function loadClientConfig() {
     const p = getClientConfigPath();
-    try { return JSON.parse(fs.readFileSync(p, 'utf8')); }
-    catch {
-        // Fall back to source-tree config.json (dev mode seed value)
-        try { return JSON.parse(fs.readFileSync(path.join(__dirname, '../../config/client.json'), 'utf8')); }
-        catch { return {}; }
+    try {
+        const config = JSON.parse(fs.readFileSync(p, 'utf8'));
+        logger.debug(`Loaded client config from ${p}`);
+        return config;
+    } catch {
+        // Fall back to source-tree client.json (dev mode seed value)
+        try {
+            const fallback = path.join(__dirname, '../../config/client.json');
+            const config = JSON.parse(fs.readFileSync(fallback, 'utf8'));
+            logger.debug(`Loaded client config from fallback ${fallback}`);
+            return config;
+        } catch {
+            logger.debug('No client config found, using defaults');
+            return {};
+        }
     }
 }
+
 let clientConfig = {};
 
+// ── Window handles ────────────────────────────────────────────────────────────
 let mainWindow = null;
 let connectionWindow = null;
 let displayPickerWindow = null;
@@ -56,7 +92,9 @@ function createMenu() {
         });
     }
 
-    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8'));
+    let pkg = { version: '?' };
+    try { pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8')); }
+    catch (err) { logger.warn(`Could not read package.json: ${err.message}`); }
 
     template.push(
         {
@@ -64,7 +102,10 @@ function createMenu() {
             submenu: [
                 {
                     label: 'New Connection',
-                    click: () => createConnectionWindow()
+                    click: () => {
+                        logger.info('User opened New Connection window');
+                        createConnectionWindow();
+                    }
                 }
             ]
         },
@@ -89,6 +130,32 @@ function createMenu() {
                 },
                 { type: 'separator' },
                 {
+                    label: 'Open Log File',
+                    click: () => {
+                        logger.info('User opened log file');
+                        shell.openPath(logger.path());
+                    }
+                },
+                {
+                    label: 'Log Level',
+                    submenu: ['debug', 'info', 'warn', 'error'].map(level => ({
+                        label: level.charAt(0).toUpperCase() + level.slice(1),
+                        type: 'radio',
+                        checked: (clientConfig.logLevel || 'info') === level,
+                        click: () => {
+                            logger.info(`Log level changed to ${level}`);
+                            logger.setLevel(level);
+                            clientConfig.logLevel = level;
+                            try {
+                                fs.writeFileSync(getClientConfigPath(), JSON.stringify(clientConfig, null, 2));
+                            } catch (err) {
+                                logger.warn(`Could not save log level: ${err.message}`);
+                            }
+                        }
+                    }))
+                },
+                { type: 'separator' },
+                {
                     label: 'Documentation',
                     click: () => shell.openExternal('https://github.com/jcksnvllxr80/FreeRTC#readme')
                 },
@@ -104,6 +171,7 @@ function createMenu() {
 }
 
 function createConnectionWindow() {
+    logger.debug('Creating connection window');
     connectionWindow = new BrowserWindow({
         width: 400,
         height: 300,
@@ -122,9 +190,14 @@ function createConnectionWindow() {
     });
 
     connectionWindow.loadFile(path.join(__dirname, 'connection.html'));
+    connectionWindow.on('closed', () => {
+        logger.debug('Connection window closed');
+        connectionWindow = null;
+    });
 }
 
 function createMainWindow() {
+    logger.debug('Creating main window');
     mainWindow = new BrowserWindow({
         width: 1200,
         height: 960,
@@ -139,25 +212,51 @@ function createMainWindow() {
     });
 
     mainWindow.webContents.on('enter-html-full-screen', () => {
+        logger.debug('Entered fullscreen');
         mainWindow.setFullScreen(true);
     });
     mainWindow.webContents.on('leave-html-full-screen', () => {
+        logger.debug('Left fullscreen');
         mainWindow.setFullScreen(false);
+    });
+
+    mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, url) => {
+        logger.error(`Page failed to load — url: ${url} code: ${errorCode} reason: ${errorDescription}`);
+    });
+
+    mainWindow.webContents.on('crashed', (_event, killed) => {
+        logger.error(`Renderer crashed (killed=${killed})`);
+    });
+
+    mainWindow.on('closed', () => {
+        logger.info('Main window closed');
+        mainWindow = null;
     });
 }
 
 async function pickDisplaySource() {
-    const sources = await desktopCapturer.getSources({
-        types: ['screen', 'window'],
-        fetchWindowIcons: true,
-        thumbnailSize: { width: 320, height: 180 }
-    });
+    logger.debug('Fetching display sources');
+    let sources;
+    try {
+        sources = await desktopCapturer.getSources({
+            types: ['screen', 'window'],
+            fetchWindowIcons: true,
+            thumbnailSize: { width: 320, height: 180 }
+        });
+    } catch (err) {
+        logger.error(`Failed to get display sources: ${err.message}`);
+        return null;
+    }
+
+    logger.debug(`Found ${sources.length} display source(s)`);
 
     if (!sources.length) {
+        logger.warn('No display sources available');
         return null;
     }
 
     if (displayPickerWindow && !displayPickerWindow.isDestroyed()) {
+        logger.debug('Display picker already open — focusing');
         displayPickerWindow.focus();
         return null;
     }
@@ -191,9 +290,7 @@ async function pickDisplaySource() {
         let settled = false;
 
         const finish = (source) => {
-            if (settled) {
-                return;
-            }
+            if (settled) return;
             settled = true;
 
             ipcMain.removeListener('display-picker:select', handleSelect);
@@ -203,6 +300,12 @@ async function pickDisplaySource() {
                 displayPickerWindow.close();
             }
             displayPickerWindow = null;
+
+            if (source) {
+                logger.info(`Display source selected: "${source.name}" (${source.id})`);
+            } else {
+                logger.info('Display picker cancelled');
+            }
             resolve(source);
         };
 
@@ -211,16 +314,12 @@ async function pickDisplaySource() {
             finish(source);
         };
 
-        const handleCancel = () => {
-            finish(null);
-        };
+        const handleCancel = () => finish(null);
 
         ipcMain.once('display-picker:select', handleSelect);
         ipcMain.once('display-picker:cancel', handleCancel);
 
-        displayPickerWindow.once('closed', () => {
-            finish(null);
-        });
+        displayPickerWindow.once('closed', () => finish(null));
 
         displayPickerWindow.webContents.once('did-finish-load', () => {
             displayPickerWindow.webContents.send('display-picker:sources', pickerSources);
@@ -236,6 +335,16 @@ async function pickDisplaySource() {
     });
 }
 
+// ── Load icon ─────────────────────────────────────────────────────────────────
+const iconPath = path.join(__dirname, '../web/public/icon.png');
+const appIcon = fs.existsSync(iconPath)
+    ? nativeImage.createFromPath(iconPath)
+    : (() => {
+        const size = 32;
+        const buf = Buffer.alloc(size * size * 4, 255);
+        return nativeImage.createFromBuffer(buf, { width: size, height: size });
+    })();
+
 // Handle self-signed certificates
 app.commandLine.appendSwitch('ignore-certificate-errors');
 
@@ -243,19 +352,25 @@ function configureDesktopPermissions() {
     const allowedPermissions = new Set(['media', 'display-capture', 'fullscreen', 'clipboard-read', 'clipboard-write', 'clipboard-sanitized-write']);
 
     session.defaultSession.setPermissionCheckHandler((_webContents, permission) => {
-        return allowedPermissions.has(permission);
+        const allowed = allowedPermissions.has(permission);
+        logger.debug(`Permission check: ${permission} → ${allowed}`);
+        return allowed;
     });
 
     session.defaultSession.setPermissionRequestHandler((_webContents, permission, callback) => {
-        callback(allowedPermissions.has(permission));
+        const allowed = allowedPermissions.has(permission);
+        logger.debug(`Permission request: ${permission} → ${allowed}`);
+        callback(allowed);
     });
 }
 
 function attemptConnect(url) {
     return new Promise((resolve, reject) => {
+        logger.debug(`HTTP probe: GET ${url}/login.html`);
         const request = https.get(url + '/login.html', {
             rejectUnauthorized: false
         }, (response) => {
+            logger.debug(`HTTP probe response: ${response.statusCode}`);
             if (response.statusCode === 200) {
                 if (!mainWindow) createMainWindow();
                 mainWindow.loadURL(url + '/login.html');
@@ -267,39 +382,55 @@ function attemptConnect(url) {
             }
         });
         request.on('error', (error) => {
+            logger.debug(`HTTP probe error: ${error.message}`);
             reject(new Error('Could not connect to server: ' + error.message));
         });
         request.end();
     });
 }
 
+// ── IPC handlers ──────────────────────────────────────────────────────────────
 ipcMain.handle('connect-to-server', async (_event, url) => {
-    await attemptConnect(url);
+    logger.info(`Connecting to ${url}`);
     try {
-        clientConfig.serverUrl = url;
-        fs.writeFileSync(getClientConfigPath(), JSON.stringify(clientConfig, null, 2));
-    } catch { /* ignore write errors */ }
+        await attemptConnect(url);
+        logger.info('Connected successfully');
+        try {
+            clientConfig.serverUrl = url;
+            fs.writeFileSync(getClientConfigPath(), JSON.stringify(clientConfig, null, 2));
+            logger.info(`Saved server URL to ${getClientConfigPath()}`);
+        } catch (err) {
+            logger.warn(`Could not save server URL: ${err.message}`);
+        }
+    } catch (err) {
+        logger.error(`Connection failed: ${err.message}`);
+        throw err;
+    }
 });
 
 ipcMain.handle('get-default-server-url', () => {
+    logger.debug(`Returning default server URL: ${clientConfig.serverUrl || '(none)'}`);
     return clientConfig.serverUrl || '';
 });
 
 ipcMain.handle('pick-display-source', async () => {
-    const source = await pickDisplaySource();
-    if (!source) {
+    logger.info('Display source picker requested');
+    try {
+        const source = await pickDisplaySource();
+        if (!source) return null;
+        return { id: source.id, name: source.name, kind: source.id.startsWith('screen:') ? 'screen' : 'window' };
+    } catch (err) {
+        logger.error(`Display source picker failed: ${err.message}`);
         return null;
     }
-
-    return {
-        id: source.id,
-        name: source.name,
-        kind: source.id.startsWith('screen:') ? 'screen' : 'window'
-    };
 });
 
+// ── App lifecycle ─────────────────────────────────────────────────────────────
 app.whenReady().then(async () => {
     clientConfig = loadClientConfig();
+    logger.setLevel(clientConfig.logLevel || 'info');
+    logger.info(`FreeRTC starting — log: ${logger.path()} — level: ${clientConfig.logLevel || 'info'}`);
+    logger.debug(`Platform: ${process.platform} — Electron: ${process.versions.electron} — Node: ${process.versions.node}`);
 
     if (process.platform === 'darwin' && app.dock) {
         app.dock.setIcon(appIcon);
@@ -309,15 +440,30 @@ app.whenReady().then(async () => {
 
     const serverUrl = clientConfig.serverUrl && clientConfig.serverUrl.trim();
     if (serverUrl) {
+        logger.info(`Auto-connecting to ${serverUrl}`);
         try {
             await attemptConnect(serverUrl);
+            logger.info('Auto-connect succeeded');
             return;
-        } catch { /* fall through to connection window */ }
+        } catch (err) {
+            logger.warn(`Auto-connect failed: ${err.message} — showing connection window`);
+        }
+    } else {
+        logger.info('No server URL configured — showing connection window');
     }
 
     createConnectionWindow();
 });
 
+process.on('uncaughtException', (err) => {
+    logger.error(`Uncaught exception: ${err.stack || err.message}`);
+});
+
+process.on('unhandledRejection', (reason) => {
+    logger.error(`Unhandled promise rejection: ${reason?.stack || reason}`);
+});
+
 app.on('window-all-closed', () => {
+    logger.info('All windows closed — quitting');
     app.quit();
 });


### PR DESCRIPTION
- Log file written to `%APPDATA%\FreeRTC\freertc.log` (writable in packaged app)
- Four levels: `debug`, `info`, `warn`, `error` — configurable via `logLevel` in `client.json`
- Logs connection attempts, auto-connect results, config saves, window lifecycle, display picker, permission checks, renderer crashes, and uncaught exceptions
- Log file accessible from **Help → Open Log File**
- Log level changeable at runtime from **Help → Log Level** — selection is saved to `client.json` and persists across restarts