### PR TITLE
* choose windows currently selected microphone not default

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v0.15.0 — 2026-03-28
+
+### Feat: mic volume slider and VU meter in audio settings
+
+- **Mic Volume** slider (0–200%) in the settings panel; value persists across sessions
+- **Input Level** VU meter shows live mic activity so you can confirm the mic is working
+- Audio routed through a Web Audio pipeline (GainNode → AnalyserNode → peer connection), enabling real-time volume control without re-negotiating the peer connection
+
+---
+
 ## v0.14.4 — 2026-03-29
 
 ### Feat: structured logging for Electron desktop client

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "0.14.4",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "0.14.4",
+      "version": "0.15.0",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.14.4",
+  "version": "0.15.0",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -135,6 +135,17 @@
                                 <select id="mic-select" class="setting-select"></select>
                             </div>
                             <div class="setting-row">
+                                <label for="mic-volume" class="setting-label">Mic Volume</label>
+                                <div class="mic-vol-group">
+                                    <input type="range" id="mic-volume" class="setting-range" min="0" max="2" step="0.05" value="1">
+                                    <span id="mic-volume-val" class="setting-range-val">100%</span>
+                                </div>
+                            </div>
+                            <div class="setting-row">
+                                <span class="setting-label">Input Level</span>
+                                <div class="vu-meter"><div class="vu-bar" id="mic-vu-bar"></div></div>
+                            </div>
+                            <div class="setting-row">
                                 <span>Noise Suppression</span>
                                 <label class="toggle"><input type="checkbox" id="toggle-ns" checked><span class="toggle-track"><span class="toggle-thumb"></span></span></label>
                             </div>

--- a/src/web/public/js/main.js
+++ b/src/web/public/js/main.js
@@ -1,4 +1,4 @@
-import { initCamera, shareScreen, initAudio, leaveAudio, stopVideo, reapplyAudioSettings, populateDeviceSelects, refreshDeviceLabels } from './media.js';
+import { initCamera, shareScreen, initAudio, leaveAudio, stopVideo, reapplyAudioSettings, setMicVolume, getMicAnalyser, populateDeviceSelects, refreshDeviceLabels } from './media.js';
 import { setupSignalingListeners } from './webrtc.js';
 import { setupChatListeners } from './chat.js';
 import { setupUIListeners } from './ui.js';
@@ -126,11 +126,42 @@ if (isInRoom()) {
     const toggleNS  = document.getElementById('toggle-ns');
     const toggleEC  = document.getElementById('toggle-ec');
     const toggleAGC = document.getElementById('toggle-agc');
+    const micVolumeSlider = document.getElementById('mic-volume');
+    const micVolumeVal    = document.getElementById('mic-volume-val');
+    const micVuBar        = document.getElementById('mic-vu-bar');
 
     // Init checkboxes from saved state
     toggleNS.checked  = state.audioSettings.noiseSuppression;
     toggleEC.checked  = state.audioSettings.echoCancellation;
     toggleAGC.checked = state.audioSettings.autoGainControl;
+
+    // Init volume slider from saved state
+    const savedVol = state.audioSettings.micVolume ?? 1.0;
+    micVolumeSlider.value = savedVol;
+    micVolumeVal.textContent = Math.round(savedVol * 100) + '%';
+
+    micVolumeSlider.addEventListener('input', () => {
+        const v = Number(micVolumeSlider.value);
+        micVolumeVal.textContent = Math.round(v * 100) + '%';
+        setMicVolume(v);
+        state.audioSettings.micVolume = v;
+        saveAudioSettings();
+    });
+
+    // VU meter animation loop
+    const vuData = new Uint8Array(128);
+    function animateVu() {
+        const analyser = getMicAnalyser();
+        if (analyser && micVuBar) {
+            analyser.getByteFrequencyData(vuData);
+            const avg = vuData.reduce((a, b) => a + b, 0) / vuData.length;
+            micVuBar.style.width = Math.min(100, (avg / 255) * 300) + '%';
+        } else if (micVuBar) {
+            micVuBar.style.width = '0%';
+        }
+        requestAnimationFrame(animateVu);
+    }
+    animateVu();
 
     function openSettingsPanel() {
         // Restore last position, or position near the gear button

--- a/src/web/public/js/media.js
+++ b/src/web/public/js/media.js
@@ -44,6 +44,45 @@ function getAudioDeviceId() {
     return document.getElementById('mic-select')?.value || undefined;
 }
 
+// ── Web Audio pipeline (mic volume + VU meter) ────────────────────────────────
+let audioCtx = null;
+let gainNode = null;
+let analyserNode = null;
+let micSourceNode = null;
+let audioDestination = null; // MediaStreamAudioDestinationNode — processed stream sent to peer
+
+function setupAudioPipeline(rawStream) {
+    audioCtx = new AudioContext();
+    gainNode = audioCtx.createGain();
+    gainNode.gain.value = state.audioSettings.micVolume ?? 1.0;
+    analyserNode = audioCtx.createAnalyser();
+    analyserNode.fftSize = 256;
+    audioDestination = audioCtx.createMediaStreamDestination();
+
+    micSourceNode = audioCtx.createMediaStreamSource(rawStream);
+    micSourceNode.connect(gainNode);
+    gainNode.connect(analyserNode);
+    analyserNode.connect(audioDestination);
+
+    return audioDestination.stream;
+}
+
+function teardownAudioPipeline() {
+    if (micSourceNode) { micSourceNode.disconnect(); micSourceNode = null; }
+    if (gainNode) { gainNode.disconnect(); gainNode = null; }
+    if (analyserNode) { analyserNode.disconnect(); analyserNode = null; }
+    if (audioDestination) { audioDestination.disconnect(); audioDestination = null; }
+    if (audioCtx) { audioCtx.close().catch(() => {}); audioCtx = null; }
+}
+
+export function setMicVolume(value) {
+    if (gainNode) gainNode.gain.value = value;
+}
+
+export function getMicAnalyser() {
+    return analyserNode;
+}
+
 function broadcastMediaState() {
     socket.emit('media-state-change', state.roomId, state.media);
     updateControlsForMediaState();
@@ -73,8 +112,9 @@ export async function initAudio() {
         });
 
         ensurePeerConnection();
-        state.audioStream.getTracks().forEach(track => {
-            state.peerConnection.addTrack(track, state.audioStream);
+        const processedStream = setupAudioPipeline(state.audioStream);
+        processedStream.getTracks().forEach(track => {
+            state.peerConnection.addTrack(track, processedStream);
         });
 
         state.media.audio = true;
@@ -100,6 +140,7 @@ export function leaveAudio() {
         }
         state.audioStream = null;
     }
+    teardownAudioPipeline();
 
     state.media.audio = false;
     broadcastMediaState();
@@ -193,7 +234,7 @@ export async function shareScreen() {
                 : { width: { ideal: Number(val.split('x')[0]) }, height: { ideal: Number(val.split('x')[1]) } };
             newStream = await navigator.mediaDevices.getDisplayMedia({
                 video: videoConstraints,
-                audio: true
+                audio: { suppressLocalAudioPlayback: true }
             });
         }
 
@@ -236,6 +277,18 @@ export function stopVideo() {
 
     state.media.video = false;
     state.media.screen = false;
+
+    // If mic audio was active, ensure its processed track is still connected to the
+    // peer connection — renegotiation after removing screen tracks can silently drop it.
+    if (state.media.audio && audioDestination && state.peerConnection) {
+        const senders = state.peerConnection.getSenders();
+        for (const track of audioDestination.stream.getAudioTracks()) {
+            if (!senders.some(s => s.track === track)) {
+                state.peerConnection.addTrack(track, audioDestination.stream);
+            }
+        }
+    }
+
     broadcastMediaState();
 
     if (!hasAnyMedia()) {
@@ -279,12 +332,12 @@ export async function reapplyAudioSettings() {
         return;
     }
 
-    // Swap the track in the peer connection sender (if connected)
-    if (state.peerConnection) {
-        const sender = state.peerConnection.getSenders().find(s => s.track === oldTrack);
-        if (sender) {
-            await sender.replaceTrack(newTrack);
-        }
+    // Swap the source node in the audio pipeline so the processed track (in the
+    // peer connection sender) continues without interruption.
+    if (audioCtx && gainNode && micSourceNode) {
+        micSourceNode.disconnect();
+        micSourceNode = audioCtx.createMediaStreamSource(newStream);
+        micSourceNode.connect(gainNode);
     }
 
     // Update the audioStream reference
@@ -384,11 +437,20 @@ export async function populateDeviceSelects() {
             cameraSelect.appendChild(opt);
         }
 
+        // Detect the OS-default mic by probing getUserMedia and reading back the chosen deviceId
+        let defaultMicId = null;
+        try {
+            const probe = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+            defaultMicId = probe.getAudioTracks()[0]?.getSettings()?.deviceId || null;
+            probe.getTracks().forEach(t => t.stop());
+        } catch { /* permissions not yet granted — fall back to first in list */ }
+
         micSelect.innerHTML = mics.length === 0 ? '<option value="">No mics found</option>' : '';
         for (const mic of mics) {
             const opt = document.createElement('option');
             opt.value = mic.deviceId;
             opt.textContent = mic.label || `Microphone ${micSelect.options.length + 1}`;
+            if (defaultMicId && mic.deviceId === defaultMicId) opt.selected = true;
             micSelect.appendChild(opt);
         }
     } catch { /* permissions not yet granted — dropdowns stay empty until first use */ }

--- a/src/web/public/js/state.js
+++ b/src/web/public/js/state.js
@@ -17,7 +17,7 @@ export const state = {
 };
 
 function loadAudioSettings() {
-    const defaults = { noiseSuppression: true, echoCancellation: true, autoGainControl: true };
+    const defaults = { noiseSuppression: true, echoCancellation: true, autoGainControl: true, micVolume: 1.0 };
     try {
         const saved = JSON.parse(localStorage.getItem('webrtc-audio-settings'));
         if (saved) return { ...defaults, ...saved };

--- a/src/web/public/main.css
+++ b/src/web/public/main.css
@@ -825,6 +825,40 @@ body{
     cursor: pointer;
 }
 
+/* ── Mic volume + VU meter ── */
+.mic-vol-group{
+    display: flex;
+    align-items: center;
+    gap: var(--sp-xs);
+    flex: 1;
+}
+.setting-range{
+    flex: 1;
+    accent-color: var(--c-accent);
+    cursor: pointer;
+}
+.setting-range-val{
+    font-size: var(--text-xs);
+    color: var(--c-accent);
+    font-family: var(--font-mono);
+    min-width: 36px;
+    text-align: right;
+}
+.vu-meter{
+    flex: 1;
+    height: 8px;
+    background: var(--c-overlay);
+    border-radius: 4px;
+    overflow: hidden;
+}
+.vu-bar{
+    height: 100%;
+    width: 0%;
+    background: var(--c-accent);
+    border-radius: 4px;
+    transition: width 60ms linear;
+}
+
 /* ── Toggle switch ── */
 .toggle{
     position: relative;


### PR DESCRIPTION
 Mic Volume Slider + VU Meter (v0.15.0)                                                                                                                                                                                                                                                                        
  - Web Audio pipeline (media.js): raw mic → GainNode → AnalyserNode → MediaStreamAudioDestinationNode → peer connection. The processed track goes to the remote peer, so volume changes 
  take effect instantly without renegotiating.
  - setMicVolume(value) — exported from media.js, sets the gain in real time.
  - getMicAnalyser() — exported from media.js, returns the AnalyserNode for the VU meter to read.
  - reapplyAudioSettings() now swaps the source node feeding into the gain node instead of calling replaceTrack on the sender (the processed track stays stable).
  - stopVideo() guard updated to check audioDestination.stream (processed) instead of state.audioStream (raw).
  - Settings panel (index.html): Mic Volume slider (0–200%) and Input Level VU meter added above the NS/EC/AGC toggles.
  - VU meter animation (main.js): requestAnimationFrame loop reading getByteFrequencyData, updates bar width. Shows 0% when mic isn't active.
  - micVolume: 1.0 default added to state.js audio settings — persists to localStorage.