### PR TITLE
fix(webrtc): preserve voice channel audio when stopping video

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v0.15.1 — 2026-03-29
+
+### Fix: voice channel audio drops when stopping video
+
+- Stopping a screen share or camera was killing the remote listener's audio playback — the `participant-updated` handler was nulling out `srcObject` on the remote video element, wiping both video and audio
+- Now only video tracks are removed from the remote stream so the voice channel continues uninterrupted
+
+---
+
 ## v0.15.0 — 2026-03-28
 
 ### Feat: mic volume slider and VU meter in audio settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/web/public/js/webrtc.js
+++ b/src/web/public/js/webrtc.js
@@ -268,10 +268,13 @@ export function setupSignalingListeners() {
         state.participants.set(socketId, data);
         renderParticipants();
 
-        // When a remote peer stops all video/screen, clear the video element
-        // immediately rather than waiting for WebRTC track events (which are unreliable).
+        // When a remote peer stops all video/screen, remove stale video tracks so
+        // the element doesn't show a frozen last frame — but keep srcObject intact
+        // so the audio channel continues to play uninterrupted.
         if (socketId !== socket.id && hadVideo && !hasVideo) {
-            document.getElementById('user-2').srcObject = null;
+            if (state.remoteStream) {
+                state.remoteStream.getVideoTracks().forEach(t => state.remoteStream.removeTrack(t));
+            }
         }
     });
 


### PR DESCRIPTION
Fix: voice channel audio drops when stopping video                                                                                                                         
- Stopping a screen share or camera was killing the remote listener's audio playback — the `participant-updated` handler was nulling out `srcObject` on the remote video element, wiping both video and audio                                                                                                                                          
- Now only video tracks are removed from the remote stream so the voice channel continues uninterrupted 