### PR TITLE
Bugfix/various fixes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## v0.16.0 — 2026-03-30
+
+### Feat: per-participant video controls and chat improvements
+
+- **Add Friend buttons in participant list** — Each participant now has an [Add Friend] button in the "In this room" list, enabling bidirectional friend addition regardless of join order. Friends can now be added mid-call.
+- **Video size presets (S/M/L)** — Control the width ratio of local and remote videos independently via compact [S][M][L] buttons in the participant list. Sizes persist in localStorage.
+- **File paste support** — Copy files from file explorer and paste them into chat (Ctrl+V) alongside drag-and-drop support. Non-image files queue in the attach preview strip; images still insert inline.
+- **Screen share echo cancellation** — Fixed echo when user B spoke while user A was sharing screen with audio. Echo cancellation now prevents remote audio from being re-captured by the system audio loopback.
+
+---
+
 ## v0.15.2 — 2026-03-30
 
 ### Arch: separate voice and video into independent peer connections

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -171,8 +171,6 @@
                     </div>
                 </div>
                 <div class="controls-spacer"></div>
-                <span id="remote-username"></span>
-                <button id="add-friend-btn" style="display:none">Add Friend</button>
             </div>
         </section>
 

--- a/src/web/public/js/chat-editor.js
+++ b/src/web/public/js/chat-editor.js
@@ -34013,13 +34013,12 @@ function createChatEditor({ editableEl, onSubmit }) {
     }
     const files = event.clipboardData?.files;
     if (files?.length) {
+      event.preventDefault();
       for (const file of files) {
-        if (file.type.startsWith("image/")) {
-          event.preventDefault();
-          insertImageFile(file);
-          return true;
-        }
+        if (file.type.startsWith("image/")) insertImageFile(file);
+        else addPendingFile(file);
       }
+      return true;
     }
     const hasTextInItems = Array.from(items || []).some((i) => i.type === "text/plain" || i.type === "text/html");
     if (!hasTextInItems && navigator.clipboard?.read) {
@@ -34053,6 +34052,15 @@ function createChatEditor({ editableEl, onSubmit }) {
           editor.commands.focus();
           insertImageFile(file);
           return;
+        }
+      }
+    }
+    const pasteFiles = e.clipboardData?.files;
+    if (pasteFiles?.length) {
+      for (const file of pasteFiles) {
+        if (!file.type.startsWith("image/")) {
+          e.preventDefault();
+          addPendingFile(file);
         }
       }
     }

--- a/src/web/public/js/friends.js
+++ b/src/web/public/js/friends.js
@@ -1,17 +1,10 @@
 import { state, socket } from './state.js';
-import { isInRoom } from './room.js';
 
-let remoteUsername = null;
 let onlineSet = new Set();
 let recentInvites = []; // { fromUsername, roomId, roomLink, ts }
 let unreadInviteCount = 0;
 
-export function getRemoteUsername() {
-    return remoteUsername;
-}
-
 export function setupFriendsListeners() {
-    const addFriendBtn = document.getElementById('add-friend-btn');
 
     // Listen for online/offline events
     socket.on('user-online', (username) => {
@@ -52,42 +45,6 @@ export function setupFriendsListeners() {
         document.addEventListener('click', () => { invitePanel.hidden = true; });
     }
 
-    if (isInRoom()) {
-        socket.on('user-connected', (userId, username) => {
-            if (username) {
-                remoteUsername = username;
-                updateAddFriendButton();
-            }
-        });
-
-        if (addFriendBtn) {
-            addFriendBtn.addEventListener('click', async () => {
-                if (!remoteUsername) return;
-                addFriendBtn.disabled = true;
-                addFriendBtn.textContent = 'Adding...';
-                try {
-                    const res = await fetch('/api/friends', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ friendUsername: remoteUsername })
-                    });
-                    if (res.ok) {
-                        addFriendBtn.textContent = 'Added!';
-                        loadFriendsList();
-                    } else {
-                        const data = await res.json();
-                        addFriendBtn.textContent = 'Add Friend';
-                        addFriendBtn.disabled = false;
-                        alert(data.error || 'Could not add friend');
-                    }
-                } catch (err) {
-                    console.error('Add friend error:', err);
-                    addFriendBtn.textContent = 'Add Friend';
-                    addFriendBtn.disabled = false;
-                }
-            });
-        }
-    }
 
     loadOnlineUsers().then(() => loadFriendsList());
 }
@@ -117,32 +74,29 @@ function updateStatusDots(username, isOnline) {
     });
 }
 
-async function updateAddFriendButton() {
-    const btn = document.getElementById('add-friend-btn');
-    const label = document.getElementById('remote-username');
-    if (!btn || !label) return;
 
-    if (!remoteUsername) {
-        btn.style.display = 'none';
-        label.textContent = '';
-        return;
-    }
-
-    label.textContent = remoteUsername;
-
+export async function addFriendForParticipant(username, btn) {
+    btn.disabled = true;
+    btn.textContent = 'Adding...';
     try {
-        const res = await fetch(`/api/friends/check/${encodeURIComponent(remoteUsername)}`);
-        const { isFriend } = await res.json();
-        if (isFriend) {
-            btn.textContent = 'Already Friends';
-            btn.disabled = true;
+        const res = await fetch('/api/friends', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ friendUsername: username })
+        });
+        if (res.ok) {
+            btn.textContent = 'Added!';
+            loadFriendsList();
         } else {
+            const data = await res.json();
             btn.textContent = 'Add Friend';
             btn.disabled = false;
+            alert(data.error || 'Could not add friend');
         }
-        btn.style.display = 'inline-block';
     } catch (err) {
-        console.error('Check friend error:', err);
+        console.error('Add friend error:', err);
+        btn.textContent = 'Add Friend';
+        btn.disabled = false;
     }
 }
 
@@ -204,7 +158,7 @@ async function loadFriendsList() {
                 const btnGroup = document.createElement('span');
                 btnGroup.className = 'friend-actions';
 
-                if (isInRoom()) {
+                if (!!state.roomId) {
                     const isOnline = onlineSet.has(f.friend_username);
                     const isInRoomWithYou = [...state.participants.values()].some(p => p.username === f.friend_username);
                     const inviteBtn = document.createElement('button');
@@ -242,9 +196,6 @@ async function loadFriendsList() {
                     removeBtn.textContent = 'Removing...';
                     await fetch(`/api/friends/${encodeURIComponent(f.friend_username)}`, { method: 'DELETE' });
                     loadFriendsList();
-                    if (remoteUsername === f.friend_username) {
-                        updateAddFriendButton();
-                    }
                 });
                 btnGroup.appendChild(removeBtn);
 

--- a/src/web/public/js/main.js
+++ b/src/web/public/js/main.js
@@ -6,6 +6,7 @@ import { setupFriendsListeners } from './friends.js';
 import { setupRoomUI, isInRoom } from './room.js';
 import { showOnboarding } from './onboarding.js';
 import { state, saveAudioSettings, loadRtcConfig } from './state.js';
+import { applyVideoSizes } from './video-size.js';
 
 // Load TURN config from server before anything that creates a peer connection
 await loadRtcConfig();
@@ -16,6 +17,9 @@ setupUIListeners();
 
 // Only initialize call features when inside a room
 if (isInRoom()) {
+    // Apply saved video size preferences
+    applyVideoSizes();
+
     // Populate device dropdowns; re-populate after first permission grant so labels appear
     populateDeviceSelects();
     navigator.mediaDevices?.addEventListener('devicechange', () => populateDeviceSelects());

--- a/src/web/public/js/media.js
+++ b/src/web/public/js/media.js
@@ -201,7 +201,8 @@ export async function shareScreen() {
                         mandatory: {
                             chromeMediaSource: 'desktop',
                             chromeMediaSourceId: source.id
-                        }
+                        },
+                        optional: [{ echoCancellation: true }]
                     },
                     video: getElectronDesktopConstraints(source.id)
                 });
@@ -218,7 +219,7 @@ export async function shareScreen() {
                 : { width: { ideal: Number(val.split('x')[0]) }, height: { ideal: Number(val.split('x')[1]) } };
             newStream = await navigator.mediaDevices.getDisplayMedia({
                 video: videoConstraints,
-                audio: { suppressLocalAudioPlayback: true }
+                audio: { suppressLocalAudioPlayback: true, echoCancellation: true }
             });
         }
 

--- a/src/web/public/js/room.js
+++ b/src/web/public/js/room.js
@@ -1,4 +1,5 @@
-import { state } from './state.js';
+import { state, socket } from './state.js';
+import { addFriendForParticipant } from './friends.js';
 
 export function isInRoom() {
     return !!state.roomId;
@@ -9,7 +10,7 @@ export function renderParticipants() {
     if (!ul) return;
 
     ul.innerHTML = '';
-    for (const [, data] of state.participants) {
+    for (const [socketId, data] of state.participants) {
         const li = document.createElement('li');
 
         // Pick dot class based on highest active media
@@ -26,6 +27,27 @@ export function renderParticipants() {
 
         li.appendChild(dot);
         li.appendChild(name);
+
+        // Add "Add Friend" button for non-self participants
+        if (socketId !== socket.id) {
+            const btn = document.createElement('button');
+            btn.className = 'participant-add-friend-btn';
+            btn.textContent = 'Add Friend';
+            btn.addEventListener('click', () => addFriendForParticipant(data.username, btn));
+            li.appendChild(btn);
+
+            // Async check if already friends
+            fetch(`/api/friends/check/${encodeURIComponent(data.username)}`)
+                .then(r => r.json())
+                .then(({ isFriend }) => {
+                    if (isFriend) {
+                        btn.textContent = 'Already Friends';
+                        btn.disabled = true;
+                    }
+                })
+                .catch(() => {});
+        }
+
         ul.appendChild(li);
     }
 }

--- a/src/web/public/js/room.js
+++ b/src/web/public/js/room.js
@@ -1,5 +1,6 @@
 import { state, socket } from './state.js';
 import { addFriendForParticipant } from './friends.js';
+import { createSizeGroup } from './video-size.js';
 
 export function isInRoom() {
     return !!state.roomId;
@@ -27,6 +28,10 @@ export function renderParticipants() {
 
         li.appendChild(dot);
         li.appendChild(name);
+
+        // Add video size controls
+        const isLocal = socketId === socket.id;
+        li.appendChild(createSizeGroup(isLocal));
 
         // Add "Add Friend" button for non-self participants
         if (socketId !== socket.id) {

--- a/src/web/public/js/video-size.js
+++ b/src/web/public/js/video-size.js
@@ -1,0 +1,68 @@
+// Video size preset management
+const LOCAL_SIZES = {
+    S: 'minmax(0, 0.5fr)',
+    M: 'minmax(0, 1fr)',
+    L: 'minmax(0, 1.5fr)'
+};
+
+const REMOTE_SIZES = {
+    S: 'minmax(0, 0.75fr)',
+    M: 'minmax(0, 1.5fr)',
+    L: 'minmax(0, 3fr)'
+};
+
+const LS_KEY_LOCAL = 'videoSizeLocal';
+const LS_KEY_REMOTE = 'videoSizeRemote';
+
+// Apply saved sizes from localStorage
+export function applyVideoSizes() {
+    const videosEl = document.getElementById('videos');
+    if (!videosEl) return;
+
+    const localSize = localStorage.getItem(LS_KEY_LOCAL) || 'M';
+    const remoteSize = localStorage.getItem(LS_KEY_REMOTE) || 'M';
+
+    videosEl.style.setProperty('--local-col', LOCAL_SIZES[localSize]);
+    videosEl.style.setProperty('--remote-col', REMOTE_SIZES[remoteSize]);
+}
+
+// Create a size preset button group [S] [M] [L]
+export function createSizeGroup(isLocal) {
+    const SIZES = isLocal ? LOCAL_SIZES : REMOTE_SIZES;
+    const LS_KEY = isLocal ? LS_KEY_LOCAL : LS_KEY_REMOTE;
+    const currentSize = localStorage.getItem(LS_KEY) || 'M';
+
+    const group = document.createElement('span');
+    group.className = 'video-size-group';
+
+    Object.keys(SIZES).forEach(size => {
+        const btn = document.createElement('button');
+        btn.className = 'video-size-btn';
+        btn.textContent = size;
+        btn.title = `${isLocal ? 'Local' : 'Remote'} video size: ${size}`;
+
+        if (size === currentSize) {
+            btn.classList.add('active');
+        }
+
+        btn.addEventListener('click', () => {
+            const videosEl = document.getElementById('videos');
+            if (!videosEl) return;
+
+            // Save preference
+            localStorage.setItem(LS_KEY, size);
+
+            // Apply size
+            const cssVar = isLocal ? '--local-col' : '--remote-col';
+            videosEl.style.setProperty(cssVar, SIZES[size]);
+
+            // Update active state
+            group.querySelectorAll('button').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+        });
+
+        group.appendChild(btn);
+    });
+
+    return group;
+}

--- a/src/web/public/main.css
+++ b/src/web/public/main.css
@@ -574,6 +574,36 @@ body{
     cursor: default;
 }
 
+.video-size-group{
+    display: flex;
+    gap: 3px;
+}
+
+.video-size-btn{
+    padding: 2px 6px;
+    font-size: 10px;
+    font-weight: 600;
+    background: var(--c-elevated);
+    color: var(--c-text-secondary);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-sm);
+    cursor: pointer;
+    transition: all var(--dur-micro) ease-out;
+}
+
+.video-size-btn:hover:not(.active){
+    background: var(--c-accent);
+    color: white;
+    border-color: var(--c-accent);
+}
+
+.video-size-btn.active{
+    background: var(--c-accent);
+    color: white;
+    border-color: var(--c-accent);
+    font-weight: 700;
+}
+
 /* ── Join/Leave audio button accents ── */
 #join-audio-btn{
     background: var(--c-accent) !important;
@@ -969,7 +999,7 @@ body{
 
 #videos{
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1.5fr);
+    grid-template-columns: var(--local-col, minmax(0, 1fr)) var(--remote-col, minmax(0, 1.5fr));
     gap: var(--sp-sm);
     width: 100%;
 }

--- a/src/web/public/main.css
+++ b/src/web/public/main.css
@@ -549,6 +549,31 @@ body{
     box-shadow: 0 0 4px var(--c-info);
 }
 
+.participant-add-friend-btn{
+    padding: 2px 8px;
+    font-size: var(--text-xs);
+    font-family: var(--font-sans);
+    font-weight: 500;
+    background: var(--c-elevated);
+    color: var(--c-text-secondary);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-sm);
+    cursor: pointer;
+    transition: background var(--dur-micro) ease-out, color var(--dur-micro) ease-out;
+    margin-left: auto;
+}
+
+.participant-add-friend-btn:hover:not(:disabled){
+    background: var(--c-success);
+    color: #fff;
+    border-color: transparent;
+}
+
+.participant-add-friend-btn:disabled{
+    opacity: 0.5;
+    cursor: default;
+}
+
 /* ── Join/Leave audio button accents ── */
 #join-audio-btn{
     background: var(--c-accent) !important;


### PR DESCRIPTION
### Feat: per-participant video controls and chat improvements                                                                                                                                                                                 
- **Add Friend buttons in participant list** — Each participant now has an [Add Friend] button in the "In this room" list, enabling bidirectional friend addition regardless of join order. Friends can now be added mid-call.                 
- **Video size presets (S/M/L)** — Control the width ratio of local and remote videos independently via compact [S][M][L] buttons in the participant list. Sizes persist in localStorage.                                               
- **File paste support** — Copy files from file explorer and paste them into chat (Ctrl+V) alongside drag-and-drop support. Non-image files queue in the attach preview strip; images still insert inline.                              
- **Screen share echo cancellation** — Fixed echo when user B spoke while user A was sharing screen with audio. Echo cancellation now prevents remote audio from being re-captured by the system audio loopback.  