### PR TITLE
feat(ux): auto-join audio, file previews, participant VU, button fixes (v0.17.0)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## v0.17.0 — 2026-03-30
+
+### Feat: UX polish — auto-join audio, file previews, participant VU, button fixes
+
+- **Auto-join audio** — Microphone audio is joined automatically when entering a room. Can be disabled via the new "Auto-join Audio" toggle in the settings panel (persists in localStorage).
+- **Chat file previews** — Shared image files now render an inline preview above the download card; video files show an inline `<video>` player. Both respect the existing image lightbox on click.
+- **Participant mic input level** — The local "me" row in the participant list now shows a live input-level VU bar (same width as the Add Friend button) instead of a blank space, keeping the button columns aligned.
+- **Notification panel positioning** — Fixed the invite/notification panel falling off the left edge of the screen; panel is now anchored left-aligned under the bell button.
+- **Controls bar left-justified** — Added explicit `justify-content: flex-start` to the controls bar.
+- **S/M/L size buttons** — Active and hovered state now uses black text (`--c-accent-text`) instead of white for legibility on the green background.
+
+---
+
 ## v0.16.0 — 2026-03-30
 
 ### Feat: per-participant video controls and chat improvements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -158,6 +158,10 @@
                                 <span>Auto Gain Control</span>
                                 <label class="toggle"><input type="checkbox" id="toggle-agc" checked><span class="toggle-track"><span class="toggle-thumb"></span></span></label>
                             </div>
+                            <div class="setting-row">
+                                <span>Auto-join Audio</span>
+                                <label class="toggle"><input type="checkbox" id="toggle-autojoin-audio" checked><span class="toggle-track"><span class="toggle-thumb"></span></span></label>
+                            </div>
                             <h5 class="settings-header" style="margin-top:var(--sp-md)">Video</h5>
                             <div class="setting-row">
                                 <label for="camera-select" class="setting-label">Camera</label>

--- a/src/web/public/js/chat.js
+++ b/src/web/public/js/chat.js
@@ -412,6 +412,23 @@ function addFileToChat(username, { filename, mimeType, data, size, msgId }) {
     attachReactionTrigger(bar, id);
 
     msg.appendChild(header);
+
+    // Inline preview for images and videos
+    if (mimeType?.startsWith('image/')) {
+        const preview = document.createElement('img');
+        preview.src = data;
+        preview.className = 'chat-file-preview-img chat-inline-img';
+        preview.alt = filename;
+        msg.appendChild(preview);
+    } else if (mimeType?.startsWith('video/')) {
+        const preview = document.createElement('video');
+        preview.src = data;
+        preview.className = 'chat-file-preview-video';
+        preview.controls = true;
+        preview.preload = 'metadata';
+        msg.appendChild(preview);
+    }
+
     msg.appendChild(card);
     msg.appendChild(bar);
     messagesDiv.appendChild(msg);

--- a/src/web/public/js/main.js
+++ b/src/web/public/js/main.js
@@ -152,17 +152,19 @@ if (isInRoom()) {
         saveAudioSettings();
     });
 
-    // VU meter animation loop
+    // VU meter animation loop — drives settings panel bar + participant list bar
     const vuData = new Uint8Array(128);
     function animateVu() {
         const analyser = getMicAnalyser();
-        if (analyser && micVuBar) {
+        let level = 0;
+        if (analyser) {
             analyser.getByteFrequencyData(vuData);
             const avg = vuData.reduce((a, b) => a + b, 0) / vuData.length;
-            micVuBar.style.width = Math.min(100, (avg / 255) * 300) + '%';
-        } else if (micVuBar) {
-            micVuBar.style.width = '0%';
+            level = Math.min(100, (avg / 255) * 300);
         }
+        if (micVuBar) micVuBar.style.width = level + '%';
+        const pVuBar = document.querySelector('.participant-vu-bar');
+        if (pVuBar) pVuBar.style.width = level + '%';
         requestAnimationFrame(animateVu);
     }
     animateVu();
@@ -257,8 +259,20 @@ if (isInRoom()) {
     toggleEC.addEventListener('change', () => handleToggle(toggleEC, 'echoCancellation'));
     toggleAGC.addEventListener('change', () => handleToggle(toggleAGC, 'autoGainControl'));
 
+    const toggleAutoJoin = document.getElementById('toggle-autojoin-audio');
+    toggleAutoJoin.checked = state.audioSettings.autoJoinAudio ?? true;
+    toggleAutoJoin.addEventListener('change', () => {
+        state.audioSettings.autoJoinAudio = toggleAutoJoin.checked;
+        saveAudioSettings();
+    });
+
     setupSignalingListeners();
     setupChatListeners();
+
+    // Auto-join audio on room entry if setting is enabled
+    if (state.audioSettings.autoJoinAudio) {
+        initAudio().catch(() => {});
+    }
 }
 
 // Friends are always available

--- a/src/web/public/js/room.js
+++ b/src/web/public/js/room.js
@@ -37,8 +37,16 @@ export function renderParticipants() {
         const isLocal = socketId === socket.id;
         controls.appendChild(createSizeGroup(isLocal));
 
-        // Add "Add Friend" button for non-self participants
-        if (socketId !== socket.id) {
+        if (socketId === socket.id) {
+            // Local user: show a live mic input-level bar in place of the Add Friend button
+            const vuWrap = document.createElement('div');
+            vuWrap.className = 'participant-vu';
+            const vuBar = document.createElement('div');
+            vuBar.className = 'participant-vu-bar';
+            vuWrap.appendChild(vuBar);
+            controls.appendChild(vuWrap);
+        } else {
+            // Remote user: Add Friend button
             const btn = document.createElement('button');
             btn.className = 'participant-add-friend-btn';
             btn.textContent = 'Add Friend';

--- a/src/web/public/js/state.js
+++ b/src/web/public/js/state.js
@@ -20,7 +20,7 @@ export const state = {
 };
 
 function loadAudioSettings() {
-    const defaults = { noiseSuppression: true, echoCancellation: true, autoGainControl: true, micVolume: 1.0 };
+    const defaults = { noiseSuppression: true, echoCancellation: true, autoGainControl: true, micVolume: 1.0, autoJoinAudio: true };
     try {
         const saved = JSON.parse(localStorage.getItem('webrtc-audio-settings'));
         if (saved) return { ...defaults, ...saved };

--- a/src/web/public/main.css
+++ b/src/web/public/main.css
@@ -137,8 +137,8 @@ body{
 
 .invite-panel{
     position: absolute;
-    top: calc(100% + 8px);
-    right: 0;
+    top: calc(100% + 6px);
+    left: 0;
     min-width: 260px;
     background: var(--c-elevated);
     border: 1px solid var(--c-border);
@@ -592,6 +592,24 @@ body{
     cursor: default;
 }
 
+/* ── Participant mic VU (local user) ── */
+.participant-vu{
+    width: 58px;
+    height: 22px;
+    background: var(--c-overlay);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-sm);
+    overflow: hidden;
+    flex-shrink: 0;
+}
+.participant-vu-bar{
+    height: 100%;
+    width: 0%;
+    background: var(--c-accent);
+    border-radius: var(--r-sm);
+    transition: width 60ms linear;
+}
+
 .video-size-group{
     display: flex;
     gap: 3px;
@@ -611,13 +629,13 @@ body{
 
 .video-size-btn:hover:not(.active){
     background: var(--c-accent);
-    color: white;
+    color: var(--c-accent-text);
     border-color: var(--c-accent);
 }
 
 .video-size-btn.active{
     background: var(--c-accent);
-    color: white;
+    color: var(--c-accent-text);
     border-color: var(--c-accent);
     font-weight: 700;
 }
@@ -1036,6 +1054,7 @@ video{
 /* ── Controls bar (below video) ── */
 .controls-bar{
     display: flex;
+    justify-content: flex-start;
     align-items: center;
     gap: var(--sp-sm);
     padding: 10px 0;
@@ -1574,6 +1593,27 @@ img.chat-inline-img{ cursor: zoom-in; }
     flex-shrink: 0;
 }
 .file-card-dl:hover{ background: var(--c-accent-muted); }
+
+/* ── File preview (image / video) ── */
+.chat-file-preview-img{
+    display: block;
+    max-width: 280px;
+    max-height: 200px;
+    border-radius: var(--r-sm);
+    border: 1px solid var(--c-border-subtle);
+    margin: var(--sp-xs) 0 2px;
+    object-fit: contain;
+    cursor: zoom-in;
+    background: var(--c-base);
+}
+.chat-file-preview-video{
+    display: block;
+    max-width: 300px;
+    border-radius: var(--r-sm);
+    border: 1px solid var(--c-border-subtle);
+    margin: var(--sp-xs) 0 2px;
+    background: var(--c-base);
+}
 
 /* ── Message reactions ── */
 .msg-reactions{


### PR DESCRIPTION
- Auto-join microphone on room entry; toggleable via new settings panel switch
- Image/video files in chat now show inline preview above the download card
- Local participant row shows live mic input-level VU bar (same size as Add Friend)
- Fix invite panel falling off left edge; now anchors left under bell button
- Controls bar explicitly left-justified; S/M/L buttons use black text on green