### PR TITLE
fix: disable invite button when friend is already in the room; fix participant list column layout

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## v0.17.2 — 2026-03-30
+
+### Fix: invite button respects live room membership
+
+- **Invite button disabled for in-room participants** — The Invite button in the friends panel is now disabled immediately when the invited user joins the room, and stays disabled until they leave. Previously it could be re-enabled after the 2-second "Sent!" cooldown even if the user was already in the room.
+- **Participant list column alignment** — Fixed grid columns (`auto auto 1fr`) so the S/M/L and Add Friend controls sit next to the participant name instead of being pushed to the far right.
+
+---
+
 ## v0.17.1 — 2026-03-30
 
 ### UX: participant list layout and expandable text file previews

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/web/public/js/friends.js
+++ b/src/web/public/js/friends.js
@@ -61,8 +61,19 @@ async function loadOnlineUsers() {
 
 function updateInviteButtons(username, isOnline) {
     document.querySelectorAll(`.invite-friend-btn[data-username="${CSS.escape(username)}"]`).forEach(btn => {
-        btn.disabled = !isOnline;
-        btn.title = isOnline ? '' : 'User is offline';
+        const isInRoom = [...state.participants.values()].some(p => p.username === username);
+        btn.disabled = isInRoom || !isOnline;
+        btn.title = isInRoom ? 'Already in the room with you' : isOnline ? '' : 'User is offline';
+    });
+}
+
+export function refreshInviteButtonStates() {
+    document.querySelectorAll('.invite-friend-btn[data-username]').forEach(btn => {
+        const username = btn.dataset.username;
+        const isInRoom = [...state.participants.values()].some(p => p.username === username);
+        const isOnline = onlineSet.has(username);
+        btn.disabled = isInRoom || !isOnline;
+        btn.title = isInRoom ? 'Already in the room with you' : isOnline ? '' : 'User is offline';
     });
 }
 
@@ -182,7 +193,7 @@ async function loadFriendsList() {
                         inviteBtn.textContent = 'Sent!';
                         setTimeout(() => {
                             inviteBtn.textContent = 'Invite';
-                            inviteBtn.disabled = false;
+                            refreshInviteButtonStates();
                         }, 2000);
                     });
                     btnGroup.appendChild(inviteBtn);

--- a/src/web/public/js/webrtc.js
+++ b/src/web/public/js/webrtc.js
@@ -1,5 +1,6 @@
 import { state, servers, socket } from './state.js';
 import { renderParticipants } from './room.js';
+import { refreshInviteButtonStates } from './friends.js';
 
 // ── per-connection state ──────────────────────────────────────────────────────
 let voiceMakingOffer = false;
@@ -312,6 +313,7 @@ export function setupSignalingListeners() {
             state.participants.set(sid, data);
         }
         renderParticipants();
+        refreshInviteButtonStates();
 
         const hasRemotePeer = [...state.participants.keys()].some(sid => sid !== socket.id);
         if (hadRemotePeer && !hasRemotePeer) {

--- a/src/web/public/main.css
+++ b/src/web/public/main.css
@@ -523,7 +523,7 @@ body{
 
 #participants li{
     display: grid;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto auto 1fr;
     align-items: center;
     gap: 8px;
     font-size: var(--text-sm);


### PR DESCRIPTION
# Fix: invite button respects live room membership
- **Invite button disabled for in-room participants** — The Invite button in the friends panel is now disabled immediately when the invited user joins the room, and stays disabled until they leave. Previously it could be re-enabled after the 2-second "Sent!" cooldown even if the user was already in the room.
- **Participant list column alignment** — Fixed grid columns (`auto auto 1fr`) so the S/M/L and Add Friend controls sit next to the participant name instead of being pushed to the far right.