### PR TITLE
fix: auto-size participant name column to widest name in list

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v0.17.3 — 2026-03-30
+
+### Fix: participant name column auto-sizes to widest name
+
+- **Dynamic name column width** — Participant name cells now automatically resize to the widest name in the list after each render, keeping all rows aligned. Falls back to a 100px minimum when only one participant is present or names are short.
+
+---
+
 ## v0.17.2 — 2026-03-30
 
 ### Fix: invite button respects live room membership

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/web/public/js/room.js
+++ b/src/web/public/js/room.js
@@ -68,6 +68,12 @@ export function renderParticipants() {
 
         ul.appendChild(li);
     }
+
+    // Sync all name columns to the widest natural width
+    const nameEls = ul.querySelectorAll('.participant-name');
+    nameEls.forEach(el => { el.style.width = ''; }); // reset so scrollWidth is natural
+    const widest = Math.max(100, ...[...nameEls].map(el => el.scrollWidth));
+    nameEls.forEach(el => { el.style.width = widest + 'px'; });
 }
 
 export function updateControlsForMediaState() {

--- a/src/web/public/main.css
+++ b/src/web/public/main.css
@@ -531,10 +531,11 @@ body{
 }
 
 .participant-name{
-    min-width: 0;
+    width: 100px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .participant-controls{


### PR DESCRIPTION
### Fix: participant name column auto-sizes to widest name
- **Dynamic name column width** — Participant name cells now automatically resize to the widest name in the list after each render, keeping all rows aligned. Falls back to a 100px minimum when only one participant is present or names are short.