### PR TITLE
fix screen share audio muting remote user

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## v1.0.0 — 2026-03-30
+
+### Screen Share Audio & Remote Mute Fixes
+
+- **Screen share no longer mutes remote audio** — Starting a screen share previously silenced the remote user's voice and locked the speaker button to prevent echo. Both restrictions are removed; you can always hear the other person and toggle mute freely.
+- **No system audio capture** — Screen share now captures video only in the Electron desktop app. In the browser, `systemAudio: 'exclude'` ensures only the shared tab's audio (e.g. a YouTube tab) is sent — window and screen shares do not capture system audio, eliminating echo paths.
+- **Speaker button always enabled** — `systemMuted` state and its lock logic removed from `remote-audio.js`; the mute button is fully user-controlled at all times.
+- **Room bar layout** — Room link input now stretches to fill the full space between the room label and the Copy Link / Leave buttons. Leave button hover is light red.
+
+---
+
 ## v0.18.2 — 2026-03-30
 
 ### Fix: camera/mic in packaged macOS app

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "0.18.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "0.18.2",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "0.18.2",
+  "version": "1.0.0",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/web/public/js/media.js
+++ b/src/web/public/js/media.js
@@ -1,7 +1,7 @@
 import { state, socket } from './state.js';
 import { ensureVoiceConnection, closeVoiceConnection, ensureVideoConnection, closeVideoConnection, addVideoTrack, addTrackGetSender, removeVideoTracks, removeScreenAudioTrack } from './webrtc.js';
 import { updateControlsForMediaState } from './room.js';
-import { setRemoteAudioSystemMuted } from './remote-audio.js';
+
 
 function formatMediaError(prefix, error) {
     const name = error?.name || 'Error';
@@ -147,7 +147,6 @@ export function leaveAudio() {
 export async function initCamera() {
     try {
         state.isSharingSystemAudio = false;
-        setRemoteAudioSystemMuted(false);
 
         if (state.localStream) {
             state.localStream.getTracks().forEach(t => t.stop());
@@ -184,7 +183,6 @@ export async function initCamera() {
 export async function shareScreen() {
     try {
         state.isSharingSystemAudio = false;
-        setRemoteAudioSystemMuted(false);
 
         if (state.localStream) {
             state.localStream.getTracks().forEach(t => t.stop());
@@ -247,7 +245,6 @@ export async function shareScreen() {
         if (screenAudioTrack) {
             state.screenAudioSender = addTrackGetSender(screenAudioTrack, state.localStream);
             state.isSharingSystemAudio = true;
-            setRemoteAudioSystemMuted(true);
         }
 
         state.media.screen = true;
@@ -268,7 +265,6 @@ export function stopVideo() {
 
     closeVideoConnection();
     state.isSharingSystemAudio = false;
-    setRemoteAudioSystemMuted(false);
 
     state.media.video = false;
     state.media.screen = false;

--- a/src/web/public/js/remote-audio.js
+++ b/src/web/public/js/remote-audio.js
@@ -2,8 +2,7 @@ const SPEAKER_ON  = 'M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05
 const SPEAKER_OFF = 'M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z';
 
 const muteState = {
-    userMuted: false,
-    systemMuted: false
+    userMuted: false
 };
 
 function getRemoteMediaEls() {
@@ -14,7 +13,7 @@ function getRemoteMediaEls() {
 }
 
 function applyMuteState() {
-    const muted = muteState.userMuted || muteState.systemMuted;
+    const muted = muteState.userMuted;
 
     for (const el of getRemoteMediaEls()) {
         el.muted = muted;
@@ -27,16 +26,8 @@ function applyMuteState() {
     const path = btn.querySelector('svg path');
     if (path) path.setAttribute('d', muted ? SPEAKER_OFF : SPEAKER_ON);
 
-    btn.disabled = muteState.systemMuted;
-    btn.title = muteState.systemMuted
-        ? 'Remote audio muted while sharing system audio to prevent echo'
-        : (muted ? 'Unmute' : 'Mute');
-    btn.setAttribute(
-        'aria-label',
-        muteState.systemMuted
-            ? 'Remote audio muted while sharing system audio to prevent echo'
-            : (muted ? 'Unmute remote audio' : 'Mute remote audio')
-    );
+    btn.title = muted ? 'Unmute' : 'Mute';
+    btn.setAttribute('aria-label', muted ? 'Unmute remote audio' : 'Mute remote audio');
 }
 
 export function initializeRemoteAudioControls() {
@@ -44,12 +35,6 @@ export function initializeRemoteAudioControls() {
 }
 
 export function toggleRemoteAudioUserMute() {
-    if (muteState.systemMuted) return;
     muteState.userMuted = !muteState.userMuted;
-    applyMuteState();
-}
-
-export function setRemoteAudioSystemMuted(muted) {
-    muteState.systemMuted = !!muted;
     applyMuteState();
 }

--- a/src/web/public/main.css
+++ b/src/web/public/main.css
@@ -468,7 +468,8 @@ body{
 }
 
 #room-link{
-    width: 260px;
+    flex: 1;
+    min-width: 0;
     padding: var(--sp-xs) var(--sp-sm);
     border: 1px solid var(--c-border);
     border-radius: var(--r-sm);
@@ -494,6 +495,12 @@ body{
 #copy-room-link:hover, #leave-room-btn:hover{
     background: var(--c-border);
     color: var(--c-text);
+}
+
+#leave-room-btn:hover{
+    background: rgba(239, 68, 68, 0.15);
+    color: #ef4444;
+    border-color: rgba(239, 68, 68, 0.3);
 }
 
 /* ── Participant list ── */
@@ -2379,7 +2386,7 @@ button:disabled{
     }
 
     #room-link{
-        width: 100%;
+        flex: 1 1 100%;
         order: 10;
     }
 


### PR DESCRIPTION
# Screen Share Audio & Remote Mute Fixes
- **Screen share no longer mutes remote audio** — Starting a screen share previously silenced the remote user's voice and locked the speaker button to prevent echo. Both restrictions are removed; you can always hear the other person and toggle mute freely.
- **No system audio capture** — Screen share now captures video only in the Electron desktop app. In the browser, `systemAudio: 'exclude'` ensures only the shared tab's audio (e.g. a YouTube tab) is sent — window and screen shares do not capture system audio, eliminating echo paths.
- **Speaker button always enabled** — `systemMuted` state and its lock logic removed from `remote-audio.js`; the mute button is fully user-controlled at all times.
- **Room bar layout** — Room link input now stretches to fill the full space between the room label and the Copy Link / Leave buttons. Leave button hover is light red.