### PR TITLE
fix: separate video/voice mute, fix gear panel off-screen in Electron

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## v1.0.1 — 2026-03-30
+
+### UX polish & bug fixes
+
+- **Mute button controls video audio only** — The speaker button on the remote video overlay now mutes/unmutes the video element (screen share / camera audio) exclusively. Voice channel audio is always on.
+- **Settings panel clamped to viewport** — Saved panel position is now clamped to window bounds on open, preventing it from rendering off-screen in the Electron app when coordinates were saved from a larger browser window.
+- **Settings panel wider** — Settings panel width increased from 260px to 286px.
+
+---
+
 ## v1.0.0 — 2026-03-30
 
 ### Screen Share Audio & Remote Mute Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/web/public/js/main.js
+++ b/src/web/public/js/main.js
@@ -173,8 +173,14 @@ if (isInRoom()) {
         // Restore last position, or position near the gear button
         const saved = (() => { try { return JSON.parse(localStorage.getItem('settings-panel-pos')); } catch { return null; } })();
         if (saved && typeof saved.x === 'number') {
-            settingsPanel.style.left = saved.x + 'px';
-            settingsPanel.style.top  = saved.y + 'px';
+            // Clamp to viewport so a position from a larger browser session
+            // doesn't leave the panel off-screen in the Electron window.
+            const pw = settingsPanel.offsetWidth  || 260;
+            const ph = settingsPanel.offsetHeight || 300;
+            const x = Math.max(0, Math.min(saved.x, window.innerWidth  - pw));
+            const y = Math.max(0, Math.min(saved.y, window.innerHeight - ph));
+            settingsPanel.style.left = x + 'px';
+            settingsPanel.style.top  = y + 'px';
         } else {
             settingsPanel.style.left = '';
             settingsPanel.style.top  = '';

--- a/src/web/public/js/remote-audio.js
+++ b/src/web/public/js/remote-audio.js
@@ -6,9 +6,9 @@ const muteState = {
 };
 
 function getRemoteMediaEls() {
+    // Only the dedicated voice audio element — NOT user-2 (video/screen-share audio)
     return [
-        document.getElementById('user-2-audio'),
-        document.getElementById('user-2')
+        document.getElementById('user-2-audio')
     ].filter(Boolean);
 }
 

--- a/src/web/public/js/ui.js
+++ b/src/web/public/js/ui.js
@@ -1,6 +1,5 @@
 import { state } from './state.js';
 import { isInRoom } from './room.js';
-import { initializeRemoteAudioControls, toggleRemoteAudioUserMute } from './remote-audio.js';
 
 export function setupUIListeners() {
     const parsePixels = (value) => {
@@ -76,14 +75,23 @@ export function setupUIListeners() {
         localStorage.setItem(LOCAL_HIDDEN_KEY, 'false');
     });
 
-    // Mute remote audio toggle
+    // Mute remote video audio toggle
+    const SPEAKER_ON  = 'M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z';
+    const SPEAKER_OFF = 'M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z';
     const muteRemoteBtn = document.getElementById('mute-remote-btn');
-    initializeRemoteAudioControls();
-    muteRemoteBtn.addEventListener('click', () => toggleRemoteAudioUserMute());
+    const remoteVideo = document.getElementById('user-2');
+    let videoAudioMuted = false;
+    muteRemoteBtn.addEventListener('click', () => {
+        videoAudioMuted = !videoAudioMuted;
+        remoteVideo.muted = videoAudioMuted;
+        const path = muteRemoteBtn.querySelector('svg path');
+        if (path) path.setAttribute('d', videoAudioMuted ? SPEAKER_OFF : SPEAKER_ON);
+        muteRemoteBtn.title = videoAudioMuted ? 'Unmute' : 'Mute';
+        muteRemoteBtn.setAttribute('aria-label', videoAudioMuted ? 'Unmute remote audio' : 'Mute remote audio');
+    });
 
     // PiP popout for remote video
     const popoutBtn   = document.getElementById('popout-btn');
-    const remoteVideo = document.getElementById('user-2');
     const PIP_ICON    = 'M19 11h-8v6h8v-6zm4 8V5c0-1.1-.9-2-2-2H3C1.9 3 1 3.9 1 5v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2zm-2 .02H3V4.98h18v14.04z';
     const EXIT_PIP_ICON = 'M21 3H3c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H3V5h18v14zM9 13h6v-2H9v2z';
 

--- a/src/web/public/main.css
+++ b/src/web/public/main.css
@@ -695,7 +695,7 @@ body{
 
 #settings-panel{
     position: fixed;
-    width: 260px;
+    width: 286px;
     max-height: calc(100vh - 32px);
     overflow-y: auto;
     background: var(--c-elevated);


### PR DESCRIPTION
# UX polish & bug fixes
- **Mute button controls video audio only** — The speaker button on the remote video overlay now mutes/unmutes the video element (screen share / camera audio) exclusively. Voice channel audio is always on.
- **Settings panel clamped to viewport** — Saved panel position is now clamped to window bounds on open, preventing it from rendering off-screen in the Electron app when coordinates were saved from a larger browser window.
- **Settings panel wider** — Settings panel width increased from 260px to 286px.