### PR TITLE
fix: recreate peer connections on user-connected to prevent double-offer

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v1.0.2 — 2026-03-31
+
+### Bug fix
+
+- **First-in-room audio now heard on join** — When Person A enabled audio before anyone else joined, their `voicePC` was left in `have-local-offer` state. On Person B's arrival an implicit SDP rollback re-fired `onnegotiationneeded`, producing a double-offer that broke the handshake. The fix closes and recreates the peer connection on `user-connected`, then re-adds local tracks so `onnegotiationneeded` fires exactly once from a clean `stable` state. The same correction is applied to the video peer connection.
+
+---
+
 ## v1.0.1 — 2026-03-30
 
 ### UX polish & bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/web/public/js/media.js
+++ b/src/web/public/js/media.js
@@ -121,6 +121,7 @@ export async function initAudio() {
     state.audioStream = rawStream;
     ensureVoiceConnection();
     const processedStream = setupAudioPipeline(state.audioStream);
+    state.processedAudioStream = processedStream;
     processedStream.getTracks().forEach(track => {
         state.voicePC.addTrack(track, processedStream);
     });
@@ -135,6 +136,7 @@ export function leaveAudio() {
         state.audioStream.getTracks().forEach(track => track.stop());
         state.audioStream = null;
     }
+    state.processedAudioStream = null;
     teardownAudioPipeline();
     closeVoiceConnection();
 

--- a/src/web/public/js/state.js
+++ b/src/web/public/js/state.js
@@ -14,6 +14,7 @@ export const state = {
     media: { audio: false, video: false, screen: false },
     participants: new Map(),  // socketId -> { username, media }
     audioStream: null,        // raw mic stream
+    processedAudioStream: null, // Web Audio pipeline output stream (what the peer actually receives)
     screenAudioSender: null,  // RTCRtpSender for screen-share audio track (if any)
     isSharingSystemAudio: false,
     audioSettings: loadAudioSettings()

--- a/src/web/public/js/webrtc.js
+++ b/src/web/public/js/webrtc.js
@@ -237,8 +237,38 @@ export function setupSignalingListeners() {
         console.log('User connected:', userId, username);
         setConnectionStatus(null);
         const { audio, video, screen } = state.media;
-        if (audio) createVoiceOffer();
-        if (video || screen) createVideoOffer();
+
+        // Close and recreate any existing peer connections so we start from a
+        // clean "stable" state.  If we leave a stale voicePC/videoPC in
+        // "have-local-offer" (from an earlier offer sent to an empty room),
+        // an implicit rollback on the next setLocalDescription() re-fires
+        // onnegotiationneeded, producing a double-offer that breaks the
+        // SDP exchange and leaves the first participant unheard.
+        if (audio) {
+            closeVoiceConnection();
+            ensureVoiceConnection();
+            if (state.processedAudioStream) {
+                state.processedAudioStream.getTracks().forEach(track => {
+                    state.voicePC.addTrack(track, state.processedAudioStream);
+                });
+            }
+            // onnegotiationneeded will fire from addTrack and send the offer
+        }
+
+        if (video || screen) {
+            const localStream = state.localStream;
+            closeVideoConnection();
+            ensureVideoConnection();
+            if (localStream) {
+                const videoTrack = localStream.getVideoTracks()[0];
+                if (videoTrack) addVideoTrack(videoTrack, localStream);
+                if (state.isSharingSystemAudio) {
+                    const audioTrack = localStream.getAudioTracks()[0];
+                    if (audioTrack) state.screenAudioSender = addTrackGetSender(audioTrack, localStream);
+                }
+            }
+            // onnegotiationneeded will fire from addTrack and send the offer
+        }
     });
 
     // Voice signaling


### PR DESCRIPTION
When the first user enabled audio/video before anyone joined, the PC was left in have-local-offer state. On the second user joining, an implicit SDP rollback re-fired onnegotiationneeded, producing a broken double-offer exchange. Close and recreate PCs on user-connected so negotiation always starts from a clean stable state.