### PR TITLE
feat: add change password

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## v1.0.4 — 2026-03-31
+
+### Feature
+
+- **Change password** — Users can now change their password from a menu in the header. Click your username to open the dropdown, choose "Change Password", enter the current password, the new password, and confirm it. Validated server-side against bcrypt, with an 8-character minimum.
+
+---
+
 ## v1.0.3 — 2026-03-31
 
 ### Bug fix

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## v1.0.4 — 2026-03-31
+
+### Feature
+
+- **Change password** — Users can now change their password from a menu in the header. Click your username to open the dropdown, choose "Change Password", enter the current password, the new password, and confirm it. Validated server-side against bcrypt, with an 8-character minimum.
+
+### Accessibility
+
+- **Screen reader support for change password form** — All three password inputs now carry `aria-describedby="cp-message"`, and the error message container has `role="alert"` and `aria-live="polite"`, so validation errors (e.g. "Passwords do not match") are announced to assistive technologies as they appear.
+
+---
+
 ## v1.0.3 — 2026-03-31
 
 ### Bug fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "freertc",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "freertc",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
         "@tiptap/extension-code-block-lowlight": "^3.20.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "freertc",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "FreeRTC — self-hosted peer-to-peer video, audio, and chat\n",
   "main": "src/desktop/main.js",
   "scripts": {

--- a/src/server/db.js
+++ b/src/server/db.js
@@ -72,4 +72,10 @@ function isFriend(username, friendUsername) {
     return !!stmt.get(username, friendUsername);
 }
 
-module.exports = { createUser, verifyUser, userExists, addFriend, removeFriend, getFriends, isFriend };
+async function updatePassword(username, newPassword) {
+    const hash = await bcrypt.hash(newPassword, SALT_ROUNDS);
+    const stmt = db.prepare('UPDATE users SET password = ? WHERE username = ?');
+    stmt.run(hash, username);
+}
+
+module.exports = { createUser, verifyUser, userExists, addFriend, removeFriend, getFriends, isFriend, updatePassword };

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -248,6 +248,27 @@ app.get('/api/me', (req, res) => {
     res.json({ username: req.session.username });
 });
 
+app.post('/api/change-password', requireAuth, async (req, res) => {
+    const { currentPassword, newPassword } = req.body;
+    if (!currentPassword || !newPassword) {
+        return res.status(400).json({ error: 'Current and new password are required' });
+    }
+    if (newPassword.length < 8) {
+        return res.status(400).json({ error: 'New password must be at least 8 characters' });
+    }
+    const username = req.session.username;
+    if (!await db.verifyUser(username, currentPassword)) {
+        return res.status(401).json({ error: 'Current password is incorrect' });
+    }
+    try {
+        await db.updatePassword(username, newPassword);
+        res.sendStatus(200);
+    } catch (err) {
+        console.error('Change password error:', err);
+        res.sendStatus(500);
+    }
+});
+
 app.get('/api/version', (req, res) => {
     // Read version once at startup instead of on every request; only expose major.minor
     res.json({ version: _appVersion });

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -119,6 +119,15 @@ const apiLimiter = rateLimit({
 });
 app.use('/api/', apiLimiter);
 
+const changePasswordLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 5,
+    message: { error: 'Too many password change attempts, please try again later' },
+    standardHeaders: true,
+    legacyHeaders: false,
+});
+app.use('/api/change-password', changePasswordLimiter);
+
 const publicPaths = new Set([
     '/login.html',
     '/login',
@@ -246,6 +255,29 @@ app.get('/api/friends/check/:friendUsername', (req, res) => {
 
 app.get('/api/me', (req, res) => {
     res.json({ username: req.session.username });
+});
+
+app.post('/api/change-password', requireAuth, async (req, res) => {
+    const { currentPassword, newPassword } = req.body;
+    if (!currentPassword || !newPassword) {
+        return res.status(400).json({ error: 'Current and new password are required' });
+    }
+    if (newPassword.length < 8) {
+        return res.status(400).json({ error: 'New password must be at least 8 characters' });
+    }
+    const username = req.session.username;
+    if (!await db.verifyUser(username, currentPassword)) {
+        return res.status(401).json({ error: 'Current password is incorrect' });
+    }
+    try {
+        await db.updatePassword(username, newPassword);
+        // Invalidate all sessions for this user — forces re-login on all devices
+        sessionDb.prepare("DELETE FROM sessions WHERE json_extract(sess, '$.username') = ?").run(username);
+        res.sendStatus(200);
+    } catch (err) {
+        console.error('Change password error:', err);
+        res.sendStatus(500);
+    }
 });
 
 app.get('/api/version', (req, res) => {

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -17,7 +17,16 @@
 
     <header id="app-header">
         <div class="header-right">
-            <span id="current-user"></span>
+            <div class="user-menu-wrap">
+                <button id="user-menu-btn" class="user-menu-btn" aria-label="User menu" aria-expanded="false">
+                    <span id="current-user"></span>
+                    <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor" aria-hidden="true"><path d="M7 10l5 5 5-5z"/></svg>
+                </button>
+                <div id="user-menu" class="user-menu" hidden>
+                    <button id="change-password-btn" class="user-menu-item">Change Password</button>
+                    <button id="logout-btn" class="user-menu-item user-menu-item--danger">Logout</button>
+                </div>
+            </div>
             <div class="invite-bell-wrap">
                 <button id="invite-bell-btn" title="Invites" aria-label="Invites">
                     <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6V11c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/></svg>
@@ -30,7 +39,6 @@
                     </ul>
                 </div>
             </div>
-            <button id="logout-btn">Logout</button>
         </div>
     </header>
 
@@ -212,6 +220,35 @@
             </div>
         </section>
     </main>
+
+<!-- Change Password modal -->
+<div id="change-password-modal" class="modal-overlay" style="display:none" role="dialog" aria-modal="true" aria-label="Change Password">
+    <div class="modal-pane">
+        <div class="modal-pane-header">
+            <span class="modal-pane-title">Change Password</span>
+            <button class="modal-close-btn" id="change-password-close" aria-label="Close">✕</button>
+        </div>
+        <form id="change-password-form" class="cp-form">
+            <div class="cp-field">
+                <label class="cp-label" for="cp-current">Current Password</label>
+                <input class="cp-input" type="password" id="cp-current" autocomplete="current-password" aria-describedby="cp-message" required>
+            </div>
+            <div class="cp-field">
+                <label class="cp-label" for="cp-new">New Password</label>
+                <input class="cp-input" type="password" id="cp-new" autocomplete="new-password" minlength="8" aria-describedby="cp-message" required>
+            </div>
+            <div class="cp-field">
+                <label class="cp-label" for="cp-confirm">Confirm New Password</label>
+                <input class="cp-input" type="password" id="cp-confirm" autocomplete="new-password" minlength="8" aria-describedby="cp-message" required>
+            </div>
+            <div id="cp-message" class="cp-message" role="alert" aria-live="polite" hidden></div>
+            <div class="modal-pane-footer cp-footer">
+                <button type="button" class="btn-ghost" id="cp-cancel">Cancel</button>
+                <button type="submit" class="btn-accent" id="cp-submit">Change Password</button>
+            </div>
+        </form>
+    </div>
+</div>
 
 <!-- Camera source picker modal -->
 <div id="camera-picker-modal" class="modal-overlay" style="display:none" role="dialog" aria-modal="true" aria-label="Select Camera">

--- a/src/web/public/index.html
+++ b/src/web/public/index.html
@@ -17,7 +17,16 @@
 
     <header id="app-header">
         <div class="header-right">
-            <span id="current-user"></span>
+            <div class="user-menu-wrap">
+                <button id="user-menu-btn" class="user-menu-btn" aria-label="User menu" aria-expanded="false">
+                    <span id="current-user"></span>
+                    <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor" aria-hidden="true"><path d="M7 10l5 5 5-5z"/></svg>
+                </button>
+                <div id="user-menu" class="user-menu" hidden>
+                    <button id="change-password-btn" class="user-menu-item">Change Password</button>
+                    <button id="logout-btn" class="user-menu-item user-menu-item--danger">Logout</button>
+                </div>
+            </div>
             <div class="invite-bell-wrap">
                 <button id="invite-bell-btn" title="Invites" aria-label="Invites">
                     <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor"><path d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6V11c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/></svg>
@@ -30,7 +39,6 @@
                     </ul>
                 </div>
             </div>
-            <button id="logout-btn">Logout</button>
         </div>
     </header>
 
@@ -212,6 +220,35 @@
             </div>
         </section>
     </main>
+
+<!-- Change Password modal -->
+<div id="change-password-modal" class="modal-overlay" style="display:none" role="dialog" aria-modal="true" aria-label="Change Password">
+    <div class="modal-pane">
+        <div class="modal-pane-header">
+            <span class="modal-pane-title">Change Password</span>
+            <button class="modal-close-btn" id="change-password-close" aria-label="Close">✕</button>
+        </div>
+        <form id="change-password-form" class="cp-form">
+            <div class="cp-field">
+                <label class="cp-label" for="cp-current">Current Password</label>
+                <input class="cp-input" type="password" id="cp-current" autocomplete="current-password" required>
+            </div>
+            <div class="cp-field">
+                <label class="cp-label" for="cp-new">New Password</label>
+                <input class="cp-input" type="password" id="cp-new" autocomplete="new-password" minlength="8" required>
+            </div>
+            <div class="cp-field">
+                <label class="cp-label" for="cp-confirm">Confirm New Password</label>
+                <input class="cp-input" type="password" id="cp-confirm" autocomplete="new-password" minlength="8" required>
+            </div>
+            <div id="cp-message" class="cp-message" hidden></div>
+            <div class="modal-pane-footer cp-footer">
+                <button type="button" class="btn-ghost" id="cp-cancel">Cancel</button>
+                <button type="submit" class="btn-accent" id="cp-submit">Change Password</button>
+            </div>
+        </form>
+    </div>
+</div>
 
 <!-- Camera source picker modal -->
 <div id="camera-picker-modal" class="modal-overlay" style="display:none" role="dialog" aria-modal="true" aria-label="Select Camera">

--- a/src/web/public/js/ui.js
+++ b/src/web/public/js/ui.js
@@ -16,11 +16,102 @@ export function setupUIListeners() {
         })
         .catch(() => {});
 
+    // User menu toggle
+    const userMenuBtn = document.getElementById('user-menu-btn');
+    const userMenu    = document.getElementById('user-menu');
+    userMenuBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const open = !userMenu.hidden;
+        userMenu.hidden = open;
+        userMenuBtn.setAttribute('aria-expanded', String(!open));
+    });
+    document.addEventListener('click', () => {
+        if (!userMenu.hidden) {
+            userMenu.hidden = true;
+            userMenuBtn.setAttribute('aria-expanded', 'false');
+        }
+    });
+
     // Logout
     document.getElementById('logout-btn').addEventListener('click', () => {
         fetch('/logout', { method: 'POST', headers: { 'X-Requested-With': 'FreeRTC' } })
             .then(() => window.location.href = '/login.html')
             .catch(err => console.error('Logout error:', err));
+    });
+
+    // Change Password modal
+    const cpModal   = document.getElementById('change-password-modal');
+    const cpForm    = document.getElementById('change-password-form');
+    const cpMessage = document.getElementById('cp-message');
+
+    function openChangePasswordModal() {
+        cpForm.reset();
+        cpMessage.hidden = true;
+        cpMessage.className = 'cp-message';
+        document.getElementById('cp-submit').disabled = false;
+        cpModal.style.display = '';
+        userMenu.hidden = true;
+        userMenuBtn.setAttribute('aria-expanded', 'false');
+        setTimeout(() => document.getElementById('cp-current').focus(), 50);
+    }
+
+    function closeChangePasswordModal() {
+        cpModal.style.display = 'none';
+    }
+
+    document.getElementById('change-password-btn').addEventListener('click', openChangePasswordModal);
+    document.getElementById('change-password-close').addEventListener('click', closeChangePasswordModal);
+    document.getElementById('cp-cancel').addEventListener('click', closeChangePasswordModal);
+    cpModal.addEventListener('click', (e) => { if (e.target === cpModal) closeChangePasswordModal(); });
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && cpModal.style.display !== 'none') closeChangePasswordModal();
+    });
+
+    cpForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const current = document.getElementById('cp-current').value;
+        const newPw   = document.getElementById('cp-new').value;
+        const confirm = document.getElementById('cp-confirm').value;
+
+        cpMessage.hidden = true;
+        cpMessage.className = 'cp-message';
+
+        if (newPw !== confirm) {
+            cpMessage.textContent = 'New passwords do not match.';
+            cpMessage.className = 'cp-message cp-error';
+            cpMessage.hidden = false;
+            return;
+        }
+
+        const submitBtn = document.getElementById('cp-submit');
+        submitBtn.disabled = true;
+
+        try {
+            const res = await fetch('/api/change-password', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'FreeRTC' },
+                body: JSON.stringify({ currentPassword: current, newPassword: newPw })
+            });
+
+            if (res.ok) {
+                cpMessage.textContent = 'Password changed successfully.';
+                cpMessage.className = 'cp-message cp-success';
+                cpMessage.hidden = false;
+                cpForm.reset();
+                setTimeout(closeChangePasswordModal, 1500);
+            } else {
+                const data = await res.json().catch(() => ({}));
+                cpMessage.textContent = data.error || 'Failed to change password.';
+                cpMessage.className = 'cp-message cp-error';
+                cpMessage.hidden = false;
+                submitBtn.disabled = false;
+            }
+        } catch (err) {
+            cpMessage.textContent = 'Network error. Please try again.';
+            cpMessage.className = 'cp-message cp-error';
+            cpMessage.hidden = false;
+            submitBtn.disabled = false;
+        }
     });
 
     if (!isInRoom()) return;

--- a/src/web/public/js/ui.js
+++ b/src/web/public/js/ui.js
@@ -16,11 +16,101 @@ export function setupUIListeners() {
         })
         .catch(() => {});
 
+    // User menu toggle
+    const userMenuBtn = document.getElementById('user-menu-btn');
+    const userMenu    = document.getElementById('user-menu');
+    userMenuBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const open = !userMenu.hidden;
+        userMenu.hidden = open;
+        userMenuBtn.setAttribute('aria-expanded', String(!open));
+    });
+    document.addEventListener('click', () => {
+        if (!userMenu.hidden) {
+            userMenu.hidden = true;
+            userMenuBtn.setAttribute('aria-expanded', 'false');
+        }
+    });
+
     // Logout
     document.getElementById('logout-btn').addEventListener('click', () => {
         fetch('/logout', { method: 'POST', headers: { 'X-Requested-With': 'FreeRTC' } })
             .then(() => window.location.href = '/login.html')
             .catch(err => console.error('Logout error:', err));
+    });
+
+    // Change Password modal
+    const cpModal   = document.getElementById('change-password-modal');
+    const cpForm    = document.getElementById('change-password-form');
+    const cpMessage = document.getElementById('cp-message');
+
+    function openChangePasswordModal() {
+        cpForm.reset();
+        cpMessage.hidden = true;
+        cpMessage.className = 'cp-message';
+        document.getElementById('cp-submit').disabled = false;
+        cpModal.style.display = '';
+        userMenu.hidden = true;
+        userMenuBtn.setAttribute('aria-expanded', 'false');
+        setTimeout(() => document.getElementById('cp-current').focus(), 50);
+    }
+
+    function closeChangePasswordModal() {
+        cpModal.style.display = 'none';
+    }
+
+    document.getElementById('change-password-btn').addEventListener('click', openChangePasswordModal);
+    document.getElementById('change-password-close').addEventListener('click', closeChangePasswordModal);
+    document.getElementById('cp-cancel').addEventListener('click', closeChangePasswordModal);
+    cpModal.addEventListener('click', (e) => { if (e.target === cpModal) closeChangePasswordModal(); });
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && cpModal.style.display !== 'none') closeChangePasswordModal();
+    });
+
+    cpForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const current = document.getElementById('cp-current').value;
+        const newPw   = document.getElementById('cp-new').value;
+        const confirm = document.getElementById('cp-confirm').value;
+
+        cpMessage.hidden = true;
+        cpMessage.className = 'cp-message';
+
+        if (newPw !== confirm) {
+            cpMessage.textContent = 'New passwords do not match.';
+            cpMessage.className = 'cp-message cp-error';
+            cpMessage.hidden = false;
+            return;
+        }
+
+        const submitBtn = document.getElementById('cp-submit');
+        submitBtn.disabled = true;
+
+        try {
+            const res = await fetch('/api/change-password', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'FreeRTC' },
+                body: JSON.stringify({ currentPassword: current, newPassword: newPw })
+            });
+
+            if (res.ok) {
+                cpMessage.textContent = 'Password changed. Redirecting to login…';
+                cpMessage.className = 'cp-message cp-success';
+                cpMessage.hidden = false;
+                setTimeout(() => { window.location.href = '/login.html'; }, 1500);
+            } else {
+                const data = await res.json().catch(() => ({}));
+                cpMessage.textContent = data.error || 'Failed to change password.';
+                cpMessage.className = 'cp-message cp-error';
+                cpMessage.hidden = false;
+                submitBtn.disabled = false;
+            }
+        } catch (err) {
+            cpMessage.textContent = 'Network error. Please try again.';
+            cpMessage.className = 'cp-message cp-error';
+            cpMessage.hidden = false;
+            submitBtn.disabled = false;
+        }
     });
 
     if (!isInRoom()) return;

--- a/src/web/public/main.css
+++ b/src/web/public/main.css
@@ -289,6 +289,140 @@ body{
     color: var(--c-text);
 }
 
+/* ── User menu dropdown ── */
+.user-menu-wrap{
+    position: relative;
+}
+
+.user-menu-btn{
+    display: flex;
+    align-items: center;
+    gap: var(--sp-xs);
+    padding: 6px 10px;
+    font-size: var(--text-sm);
+    font-family: var(--font-mono);
+    background: transparent;
+    color: var(--c-text-secondary);
+    border: 1px solid transparent;
+    border-radius: var(--r-sm);
+    cursor: pointer;
+    transition: background var(--dur-micro) ease-out,
+                color var(--dur-micro) ease-out,
+                border-color var(--dur-micro) ease-out;
+}
+.user-menu-btn:hover,
+.user-menu-btn[aria-expanded="true"]{
+    background: var(--c-elevated);
+    color: var(--c-text);
+    border-color: var(--c-border);
+}
+
+.user-menu{
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    background: var(--c-elevated);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-md);
+    box-shadow: 0 8px 24px rgba(0,0,0,0.6);
+    min-width: 160px;
+    overflow: hidden;
+    z-index: 200;
+    animation: modal-in 120ms ease-out;
+}
+
+.user-menu-item{
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 9px 14px;
+    background: none;
+    border: none;
+    color: var(--c-text-secondary);
+    font-size: var(--text-sm);
+    font-family: var(--font-sans);
+    cursor: pointer;
+    transition: background var(--dur-micro) ease-out, color var(--dur-micro) ease-out;
+}
+.user-menu-item:hover{
+    background: var(--c-overlay);
+    color: var(--c-text);
+}
+.user-menu-item--danger:hover{
+    color: var(--c-error);
+}
+
+/* ── Change password form ── */
+.cp-form{
+    padding: var(--sp-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-md);
+}
+
+.cp-field{
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.cp-label{
+    font-size: var(--text-sm);
+    color: var(--c-text-secondary);
+    font-weight: 500;
+}
+
+.cp-input{
+    width: 100%;
+    box-sizing: border-box;
+    background: var(--c-base);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-sm);
+    color: var(--c-text);
+    font-size: var(--text-sm);
+    font-family: var(--font-sans);
+    padding: 8px 10px;
+    outline: none;
+    transition: border-color var(--dur-micro) ease-out;
+}
+.cp-input:focus{ border-color: var(--c-accent); }
+
+.cp-message{
+    font-size: var(--text-sm);
+    padding: 7px 10px;
+    border-radius: var(--r-sm);
+    border: 1px solid transparent;
+}
+.cp-message.cp-error{
+    background: rgba(220,53,69,0.1);
+    border-color: var(--c-error);
+    color: var(--c-error);
+}
+.cp-message.cp-success{
+    background: rgba(40,167,69,0.1);
+    border-color: var(--c-success);
+    color: var(--c-success);
+}
+
+.cp-footer{
+    gap: var(--sp-sm);
+}
+
+.btn-accent{
+    background: var(--c-accent);
+    color: var(--c-accent-text);
+    border: none;
+    font-size: var(--text-sm);
+    font-family: var(--font-sans);
+    font-weight: 600;
+    padding: 6px 14px;
+    border-radius: var(--r-sm);
+    cursor: pointer;
+    transition: background var(--dur-micro) ease-out;
+}
+.btn-accent:hover{ background: var(--c-accent-hover); }
+.btn-accent:disabled{ opacity: 0.5; cursor: not-allowed; }
+
 /* ── Lobby ── */
 #lobby{
     padding: var(--sp-2xl) var(--sp-md);


### PR DESCRIPTION
## Feature
- **Change password** — Users can now change their password from a menu in the header. Click your username to open the dropdown, choose "Change Password", enter the current password, the new password, and confirm it. Validated server-side against bcrypt, with an 8-character minimum.

## Accessibility
- **Screen reader support for change password form** — All three password inputs now carry `aria-describedby="cp-message"`, and the error message container has `role="alert"` and `aria-live="polite"`, so validation errors (e.g. "Passwords do not match") are announced to assistive technologies as they appear.